### PR TITLE
Add GitHub Actions audit tooling and secrets inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,20 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env  # then edit values
 uvicorn app.main:app --reload
+
+## Tooling
+
+- [GitHub Actions audit playbook](./docs/github-actions-audit.md)
+- [Supabase Migration Guide](./supabase/README.md)
+
+### GitHub Actions audit helpers
+
+- `scripts/audit_workflows.py` – Query the GitHub API for workflow health
+  across GaiaEyes repositories, gather failure summaries, and produce a
+  Markdown report with referenced secrets and variables.
+- `scripts/scan-secrets.sh` – Quickly list `${{ secrets.* }}` and `${{ vars.* }}`
+  usages within the repository to keep `REQUIRED_SECRETS.md` accurate.
+
+Run these tools whenever workflows are updated or new repositories are
+added to GaiaEyesHQ to maintain an up-to-date inventory of required
+secrets and configuration knobs.

--- a/REQUIRED_SECRETS.md
+++ b/REQUIRED_SECRETS.md
@@ -1,0 +1,66 @@
+# Required secrets and variables
+
+This document tracks GitHub Actions secrets and variables referenced by
+this repository as well as the GaiaEyes repos covered by the audit
+scripts.
+
+## gaiaeyes-backend (this repo)
+
+The GitHub Actions workflows reference the following secrets. Non-
+sensitive entries (if any) should move to repository variables.
+
+| Name | Purpose | Source of truth |
+| ---- | ------- | ---------------- |
+| `EARTHSCOPE_USER_ID` | Earthscope integration user identifier | GitHub org secret |
+| `EARTHSCOPE_WEBHOOK_URL` | Earthscope webhook endpoint | GitHub org secret |
+| `FB_ACCESS_TOKEN` | Facebook Graph API token | GitHub org secret |
+| `FB_PAGE_ID` | Facebook page identifier | GitHub org secret |
+| `GAIAEYES_MEDIA_SSH_KEY` | Deploy key for media repository | GitHub org secret |
+| `GAIAEYES_MEDIA_TOKEN` | Token for accessing private media repo | GitHub org secret |
+| `GAIA_TIMEZONE` | Canonical timezone value | Consider moving to repository variable |
+| `GEOSPACE_FRAME_URL` | External data endpoint | Consider moving to repository variable |
+| `GITHUB_TOKEN` | GitHub-provided token (auto) | Actions default |
+| `IG_USER_ID` | Instagram account identifier | GitHub org secret |
+| `MEDIA_CDN_BASE` | CDN root for published assets | Consider moving to repository variable |
+| `MEDIA_REPO_NAME` | Media repository name | Consider moving to repository variable |
+| `MEDIA_REPO_OWNER` | Media repository owner | Consider moving to repository variable |
+| `MEDIA_ROOT` | Filesystem root for media sync | GitHub org secret |
+| `NASA_API_KEY` | NASA APIs | GitHub org secret |
+| `OPENAI_API_KEY` | OpenAI access key | GitHub org secret |
+| `SOCIAL_WEBHOOK_URL` | Social automation webhook | GitHub org secret |
+| `SUPABASE_DB_URL` | Supabase pooled database URL | GitHub org secret |
+| `SUPABASE_REST_URL` | Supabase REST endpoint | Consider moving to repository variable |
+| `SUPABASE_SERVICE_KEY` | Supabase service role key | GitHub org secret |
+| `SUPABASE_SERVICE_ROLE` | Supabase service role secret | GitHub org secret |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key (duplicate) | GitHub org secret |
+| `SUPABASE_URL` | Supabase project URL | Consider moving to repository variable |
+| `SYMH_URL` | External SYMH data source | Consider moving to repository variable |
+| `WEBHOOK_SECRET` | Shared secret for webhook verification | GitHub org secret |
+| `WP_ALT_USERNAME` | Alternate WordPress account | GitHub org secret |
+| `WP_APP_PASSWORD` | WordPress application password | GitHub org secret |
+| `WP_BASE_URL` | WordPress base URL | Consider moving to repository variable |
+| `WP_CATEGORY_ID` | WordPress category id(s) | Consider moving to repository variable |
+| `WP_CTA_HTML` | CTA markup for posts | Consider moving to repository variable |
+| `WP_TAG_IDS` | WordPress tag ids | Consider moving to repository variable |
+| `WP_USERNAME` | WordPress username | GitHub org secret |
+
+Run `./scripts/scan-secrets.sh` after any workflow change to keep this
+section up to date.
+
+## GaiaEyesHQ/gaiaeyes-ios
+- _Populate after running_ `./scripts/audit_workflows.py GaiaEyesHQ/gaiaeyes-ios`
+
+## GaiaEyesHQ/DataExport
+- _Populate after running_ `./scripts/audit_workflows.py GaiaEyesHQ/DataExport`
+
+## GaiaEyesHQ/gaiaeyes-wp
+- _Populate after running_ `./scripts/audit_workflows.py GaiaEyesHQ/gaiaeyes-wp`
+
+For each secret or variable, document:
+
+| Name | Type | Purpose | Source of truth |
+| ---- | ---- | ------- | ---------------- |
+| e.g. `GAIAEYES_MEDIA_TOKEN` | Secret | Access private media repo | GitHub org secret |
+
+Non-sensitive constants should be stored as repository variables instead
+of secrets.

--- a/docs/github-actions-audit.md
+++ b/docs/github-actions-audit.md
@@ -1,0 +1,52 @@
+# GitHub Actions audit playbook
+
+This repository now includes tooling to audit the GaiaEyes GitHub
+organization for failing workflows and missing secrets.
+
+## 1. Generate an audit report
+
+```bash
+export GITHUB_TOKEN=<token with repo+workflow scope>
+./scripts/audit_workflows.py \
+  GaiaEyesHQ/gaiaeyes-ios \
+  GaiaEyesHQ/DataExport \
+  GaiaEyesHQ/gaiaeyes-wp \
+  --output report.md
+```
+
+The script will download workflow metadata, capture the latest run
+status, and enumerate every `${{ secrets.* }}` and `${{ vars.* }}`
+reference. The generated Markdown file is ready to paste into an audit
+issue or pull request description.
+
+> **Tip:** Re-run the script after applying fixes to attach links to the
+> most recent green runs.
+
+## 2. List referenced secrets in the current repo
+
+```bash
+./scripts/scan-secrets.sh
+```
+
+The helper script relies on `rg`/`ripgrep` and prints every secret or
+variable reference along with its file and line number. Use it to keep
+`REQUIRED_SECRETS.md` up to date.
+
+## 3. Recommended follow-up actions
+
+1. **Document secrets** – update `REQUIRED_SECRETS.md` (or per-repo
+   README) with the names, purpose, and system of record for each secret
+   or variable.
+2. **Verify repository settings** – confirm that workflow permissions are
+   set to **Read and write** and that organization secrets/variables are
+   inherited where appropriate.
+3. **Review failures** – for each workflow flagged in the report, drill
+   into the failing step to determine whether the cause is missing
+   configuration (secrets, variables, or permissions), outdated runtime
+   requirements, or broken scripts. Capture the fix in a pull request and
+   re-run the workflow to validate.
+4. **Prefer variables for non-sensitive data** – constants that are not
+   sensitive should move from `${{ secrets.* }}` to `${{ vars.* }}`.
+
+Keeping these steps in the project workflow ensures GaiaEyes repos stay
+healthy and actionable.

--- a/scripts/audit_workflows.py
+++ b/scripts/audit_workflows.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Audit GitHub Actions workflows for a list of repositories.
+
+The script queries the GitHub API for workflow run status and scans each
+workflow file for secret/variable references. It requires the
+``GITHUB_TOKEN`` environment variable to be set with a token that has
+``repo`` and ``workflow`` scopes.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+import requests
+
+API_ROOT = "https://api.github.com"
+
+
+@dataclass
+class WorkflowRunSummary:
+    name: str
+    path: str
+    url: Optional[str]
+    status: Optional[str]
+    conclusion: Optional[str]
+    failure_step: Optional[str]
+    failure_details: Optional[str]
+
+
+@dataclass
+class RepoAudit:
+    repo: str
+    workflows: List[WorkflowRunSummary] = field(default_factory=list)
+    secrets: Dict[str, List[str]] = field(default_factory=lambda: {"secrets": [], "vars": []})
+    default_workflow_permissions: Optional[str] = None
+    can_approve_pr_reviews: Optional[bool] = None
+
+
+def github_request(token: str, method: str, path: str, **kwargs) -> requests.Response:
+    headers = kwargs.pop("headers", {})
+    headers["Authorization"] = f"Bearer {token}"
+    headers["Accept"] = "application/vnd.github+json"
+    response = requests.request(method, f"{API_ROOT}{path}", headers=headers, timeout=30, **kwargs)
+    if response.status_code >= 400:
+        raise RuntimeError(f"GitHub API request failed for {path}: {response.status_code} {response.text}")
+    return response
+
+
+def list_workflows(token: str, repo: str) -> Iterable[dict]:
+    response = github_request(token, "GET", f"/repos/{repo}/actions/workflows")
+    data = response.json()
+    return data.get("workflows", [])
+
+
+def latest_run(token: str, repo: str, workflow_id: int) -> Optional[dict]:
+    response = github_request(
+        token,
+        "GET",
+        f"/repos/{repo}/actions/workflows/{workflow_id}/runs",
+        params={"per_page": 1},
+    )
+    runs = response.json().get("workflow_runs", [])
+    return runs[0] if runs else None
+
+
+def summarize_failure_step(token: str, repo: str, run_id: int) -> tuple[Optional[str], Optional[str]]:
+    response = github_request(
+        token,
+        "GET",
+        f"/repos/{repo}/actions/runs/{run_id}/jobs",
+        params={"per_page": 1},
+    )
+    jobs = response.json().get("jobs", [])
+    if not jobs:
+        return None, None
+
+    steps = jobs[0].get("steps", [])
+    for step in steps:
+        if step.get("conclusion") == "failure":
+            return step.get("name"), step.get("completed_at")
+    return None, None
+
+
+def fetch_workflow_content(token: str, repo: str, path: str) -> str:
+    response = github_request(token, "GET", f"/repos/{repo}/contents/{path}")
+    data = response.json()
+    if isinstance(data, list):
+        raise RuntimeError(f"Expected file but found directory for {path}")
+    content = data.get("content", "")
+    encoding = data.get("encoding")
+    if encoding != "base64":
+        raise RuntimeError(f"Unexpected encoding for {path}: {encoding}")
+    return base64.b64decode(content).decode("utf-8", errors="replace")
+
+
+SECRET_PATTERN = re.compile(r"\$\{\{\s*(secrets|vars)\.([A-Za-z0-9_]+)\s*}}")
+
+
+def extract_secret_references(text: str) -> Dict[str, List[str]]:
+    discovered: Dict[str, set[str]] = {"secrets": set(), "vars": set()}
+    for match in SECRET_PATTERN.finditer(text):
+        prefix, name = match.groups()
+        discovered[prefix].add(name)
+    return {key: sorted(values) for key, values in discovered.items()}
+
+
+def merge_secret_maps(destination: Dict[str, List[str]], source: Dict[str, List[str]]) -> None:
+    for key, values in source.items():
+        existing = set(destination.get(key, []))
+        existing.update(values)
+        destination[key] = sorted(existing)
+
+
+def get_workflow_permissions(token: str, repo: str) -> tuple[Optional[str], Optional[bool]]:
+    response = github_request(token, "GET", f"/repos/{repo}/actions/permissions")
+    data = response.json()
+    return data.get("default_workflow_permissions"), data.get("can_approve_pull_request_reviews")
+
+
+def audit_repo(token: str, repo: str) -> RepoAudit:
+    audit = RepoAudit(repo=repo)
+    workflows = list_workflows(token, repo)
+
+    for workflow in workflows:
+        run = latest_run(token, repo, workflow["id"])
+        failure_step = None
+        failure_details = None
+        url = run.get("html_url") if run else None
+        status = run.get("status") if run else None
+        conclusion = run.get("conclusion") if run else None
+        if run and conclusion == "failure":
+            failure_step, failure_details = summarize_failure_step(token, repo, run["id"])
+
+        audit.workflows.append(
+            WorkflowRunSummary(
+                name=workflow.get("name", "unknown"),
+                path=workflow.get("path", ""),
+                url=url,
+                status=status,
+                conclusion=conclusion,
+                failure_step=failure_step,
+                failure_details=failure_details,
+            )
+        )
+
+        if workflow.get("path"):
+            content = fetch_workflow_content(token, repo, workflow["path"])
+            merge_secret_maps(audit.secrets, extract_secret_references(content))
+
+    default_permissions, can_approve = get_workflow_permissions(token, repo)
+    audit.default_workflow_permissions = default_permissions
+    audit.can_approve_pr_reviews = can_approve
+
+    return audit
+
+
+def render_markdown(audits: Iterable[RepoAudit]) -> str:
+    lines: List[str] = []
+    for audit in audits:
+        lines.append(f"## {audit.repo}\n")
+        lines.append("| Workflow | Status | Conclusion | Failure Step | Details | URL |")
+        lines.append("| --- | --- | --- | --- | --- | --- |")
+        for workflow in audit.workflows:
+            lines.append(
+                "| {name} ({path}) | {status} | {conclusion} | {failure_step} | {failure_details} | [link]({url}) |".format(
+                    name=workflow.name,
+                    path=workflow.path,
+                    status=workflow.status or "-",
+                    conclusion=workflow.conclusion or "-",
+                    failure_step=workflow.failure_step or "-",
+                    failure_details=workflow.failure_details or "-",
+                    url=workflow.url or "#",
+                )
+            )
+
+        lines.append("")
+        lines.append("### Referenced secrets and variables")
+        if audit.secrets["secrets"] or audit.secrets["vars"]:
+            lines.append("- Secrets: " + ", ".join(audit.secrets["secrets"]) if audit.secrets["secrets"] else "- Secrets: none")
+            lines.append("- Variables: " + ", ".join(audit.secrets["vars"]) if audit.secrets["vars"] else "- Variables: none")
+        else:
+            lines.append("No secrets or variables referenced.")
+
+        if audit.default_workflow_permissions:
+            permission_text = audit.default_workflow_permissions
+        else:
+            permission_text = "unknown"
+        lines.append("")
+        lines.append(f"Default workflow permissions: **{permission_text}**")
+        if audit.can_approve_pr_reviews is not None:
+            lines.append(
+                "Can approve pull request reviews: **{}**".format("yes" if audit.can_approve_pr_reviews else "no")
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit GitHub Actions workflows")
+    parser.add_argument(
+        "repos",
+        nargs="*",
+        default=[
+            "GaiaEyesHQ/gaiaeyes-ios",
+            "GaiaEyesHQ/DataExport",
+            "GaiaEyesHQ/gaiaeyes-wp",
+        ],
+        help="Repositories to audit in the form owner/name.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Optional path to write the Markdown report. Defaults to stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN environment variable is required", file=sys.stderr)
+        return 1
+
+    audits: List[RepoAudit] = []
+    for repo in args.repos:
+        try:
+            audits.append(audit_repo(token, repo))
+        except Exception as exc:  # noqa: BLE001 - Provide context to the caller
+            print(f"Failed to audit {repo}: {exc}", file=sys.stderr)
+
+    report = render_markdown(audits)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(report)
+    else:
+        print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/scan-secrets.sh
+++ b/scripts/scan-secrets.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ripgrep (rg) is required to scan for secrets references." >&2
+  exit 1
+fi
+
+pattern='\$\{\{\s*(secrets|vars)\.[^}]+\}\}'
+
+target_paths=("$@")
+if [ ${#target_paths[@]} -eq 0 ]; then
+  if [ -d .github/workflows ]; then
+    target_paths=(".github/workflows")
+  else
+    target_paths=(".")
+  fi
+fi
+
+rg --no-heading --line-number --color=never "$pattern" "${target_paths[@]}"


### PR DESCRIPTION
## Summary
- add `scripts/audit_workflows.py` to pull workflow health, failure context, and secret references across GaiaEyes repos
- add `scripts/scan-secrets.sh`, a ripgrep-based helper to inventory `${{ secrets.* }}`/`${{ vars.* }}` usages
- document the audit process and required secrets for GaiaEyes repositories

## Testing
- python -m compileall scripts/audit_workflows.py
- ./scripts/scan-secrets.sh


------
https://chatgpt.com/codex/tasks/task_e_68ee7158df10832a84c99ea8047b4850