### PR TITLE
fix: guard magnetosphere media commit when sparkline missing

### DIFF
--- a/.github/workflows/magnetosphere.yml
+++ b/.github/workflows/magnetosphere.yml
@@ -29,7 +29,7 @@ jobs:
           git remote -v
         env:
           GAIAEYES_MEDIA_TOKEN: ${{ secrets.GAIAEYES_MEDIA_TOKEN }}
-      - run: pip install supabase requests numpy typing-extensions
+      - run: pip install supabase requests numpy typing-extensions matplotlib
       - env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -43,19 +43,24 @@ jobs:
           MEDIA_OUT_DIR: ${{ github.workspace }}/media/data
           WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
         run: python bots/magnetosphere/magnetosphere_collect.py
-      - name: Commit & push media JSON
+      - name: Commit & push media assets
         if: always()
         working-directory: media
         run: |
           set -euo pipefail
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/*.json || true
+          shopt -s nullglob
+          files=(data/*.json data/*.png)
+          if [ ${#files[@]} -gt 0 ]; then
+            git add "${files[@]}"
+          fi
+          shopt -u nullglob
           if git diff --cached --quiet; then
-            echo "No JSON changes to commit."
+            echo "No media changes to commit."
             exit 0
           fi
-          git commit -m "chore(magnetosphere): update latest JSON [skip ci]"
+          git commit -m "chore(magnetosphere): update latest visuals & JSON [skip ci]"
           # Robust push with rebase (no force) and bounded retries for concurrent writers
           for attempt in 1 2 3; do
             echo "Push attempt ${attempt}..."

--- a/supabase/migrations/20251015142333_create_marts_magnetosphere_last24_view.sql
+++ b/supabase/migrations/20251015142333_create_marts_magnetosphere_last24_view.sql
@@ -1,0 +1,9 @@
+CREATE SCHEMA IF NOT EXISTS marts;
+
+CREATE OR REPLACE VIEW marts.magnetosphere_last_24h AS
+SELECT ts, r0_re, kp_latest
+FROM ext.magnetosphere_pulse
+WHERE ts > now() - interval '24 hours'
+ORDER BY ts ASC;
+
+ALTER VIEW marts.magnetosphere_last_24h OWNER TO postgres;


### PR DESCRIPTION
## Summary
- prevent the magnetosphere workflow from failing `git add` when the sparkline PNG is absent by using a nullglob-safe file list before staging

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68efad8488dc832a8c19e4d4541e8693