### PR TITLE
fix: guard magnetosphere media commit when sparkline missing

### DIFF
--- a/.github/workflows/magnetosphere.yml
+++ b/.github/workflows/magnetosphere.yml
@@ -29,7 +29,7 @@ jobs:
           git remote -v
         env:
           GAIAEYES_MEDIA_TOKEN: ${{ secrets.GAIAEYES_MEDIA_TOKEN }}
-      - run: pip install supabase requests numpy typing-extensions
+      - run: pip install supabase requests numpy typing-extensions matplotlib
       - env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -43,19 +43,20 @@ jobs:
           MEDIA_OUT_DIR: ${{ github.workspace }}/media/data
           WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
         run: python bots/magnetosphere/magnetosphere_collect.py
-      - name: Commit & push media JSON
+      - name: Commit & push media assets
         if: always()
         working-directory: media
         run: |
           set -euo pipefail
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/*.json || true
+          find data -maxdepth 1 -type f \( -name '*.json' -o -name '*.png' \) -print0 \
+            | xargs -0r git add
           if git diff --cached --quiet; then
-            echo "No JSON changes to commit."
+            echo "No media changes to commit."
             exit 0
           fi
-          git commit -m "chore(magnetosphere): update latest JSON [skip ci]"
+          git commit -m "chore(magnetosphere): update latest visuals & JSON [skip ci]"
           # Robust push with rebase (no force) and bounded retries for concurrent writers
           for attempt in 1 2 3; do
             echo "Push attempt ${attempt}..."


### PR DESCRIPTION
## Summary
- prevent the magnetosphere workflow from failing `git add` when the sparkline PNG is absent by staging only existing JSON/PNG files with `find`
- remove the Supabase migration for the `marts.magnetosphere_last_24h` view per request

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68efad8488dc832a8c19e4d4541e8693