### PR TITLE
Fix Bz stat overlay label/value mismatch

### DIFF
--- a/bots/earthscope_post/README.md
+++ b/bots/earthscope_post/README.md
@@ -48,6 +48,8 @@ Plan observability by deciding how to monitor worker runs and webhook deliveries
   renders only the stats overlay, skips git pushes/CSV writes, and pipes the JPG to `./out` for deterministic tests.
 - Bz is sourced from `/v1/features/today` when `GAIA_API_BASE_URL` is set, falling back to Supabase `ext.space_weather`
   (latest row) before resorting to historic marts; negative values automatically trigger the alert color scheme.
+- Daily stats overlays prefer `bz_min` when available, fall back to `bz_current`, then `bz_now`, and dynamically relabel
+  the card as “Bz (min)” vs “Bz (current)” so the plotted metric always matches the caption.
 
 # Gaia Eyes App
 

--- a/tests/bots/test_gaia_eyes_viral_bot_stats.py
+++ b/tests/bots/test_gaia_eyes_viral_bot_stats.py
@@ -7,35 +7,66 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from bots.earthscope_post.gaia_eyes_viral_bot import build_stats_rows
+from bots.earthscope_post.gaia_eyes_viral_bot import build_stats_rows, StatRow
 
 
-def _value_for_label(rows, label):
+def _row_for_label(rows: list[StatRow], label: str) -> StatRow:
     for row in rows:
-        if row[0] == label:
-            return row[1]
+        if row.label == label:
+            return row
     raise AssertionError(f"Missing row for {label}")
 
 
-def test_bz_negative_includes_value():
+def test_bz_prefers_min_and_applies_severe_styling():
     feats = {
         "kp_max": 4.5,
-        "bz_current": -7.34,
+        "bz_min": -8.0,
+        "bz_current": -2.0,
         "sw_speed_avg": 505,
         "sch_any_fundamental_avg_hz": 7.83,
     }
 
     rows = build_stats_rows(feats, "avg")
-    assert _value_for_label(rows, "Bz (min)") == "-7.3 nT"
+    bz_row = _row_for_label(rows, "Bz (min)")
+
+    assert bz_row.display == "-8.0 nT"
+    assert bz_row.raw_value == pytest.approx(-8.0)
+    assert bz_row.color == (239, 106, 106, 220)
+
+
+def test_bz_falls_back_to_current_with_label():
+    feats = {
+        "kp_max": 3.2,
+        "bz_min": None,
+        "bz_current": -3.4,
+        "sw_speed_avg": 455,
+        "sch_any_fundamental_avg_hz": 7.7,
+    }
+
+    rows = build_stats_rows(feats, "avg")
+    bz_row = _row_for_label(rows, "Bz (current)")
+
+    assert bz_row.display == "-3.4 nT"
+    assert bz_row.raw_value == pytest.approx(-3.4)
+    assert bz_row.color == (100, 160, 220, 220)
 
 
 @pytest.mark.parametrize(
     "feats",
     [
         {"kp_max": 2.1, "sw_speed_avg": 420, "sch_any_fundamental_avg_hz": 7.6},
-        {"kp_max": 2.1, "bz_min": None, "sw_speed_avg": 420, "sch_any_fundamental_avg_hz": 7.6},
+        {
+            "kp_max": 2.1,
+            "bz_min": None,
+            "bz_current": None,
+            "bz_now": None,
+            "sw_speed_avg": 420,
+            "sch_any_fundamental_avg_hz": 7.6,
+        },
     ],
 )
 def test_bz_missing_uses_placeholder(feats):
     rows = build_stats_rows(feats, "avg")
-    assert _value_for_label(rows, "Bz (min)") == "—"
+    bz_row = _row_for_label(rows, "Bz (current)")
+    assert bz_row.display == "—"
+    assert bz_row.raw_value is None


### PR DESCRIPTION
## Summary
- prefer `bz_min` for the stats card, fall back to current/now, and log the chosen Bz source
- update the stats row structure to carry raw values, format Bz with a sign, and keep styling tied to the selected metric
- document the selection order in the Earthscope bot README and add regression tests for min, current, and missing data cases

## Testing
- python -m compileall bots/earthscope_post
- pytest -q tests/bots/test_gaia_eyes_viral_bot_stats.py

------
https://chatgpt.com/codex/tasks/task_e_68f6a36e438c832a8fc26c167cfbe301