### PR TITLE
chore: replace hard-coded gennwu references and add link lint guard

### DIFF
--- a/.github/workflows/lint-links.yml
+++ b/.github/workflows/lint-links.yml
@@ -1,0 +1,12 @@
+name: lint-links
+on: [push, pull_request]
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if old owner appears
+        run: |
+          if grep -RIn --exclude-dir=.git -E "gennwu(|.github.io|/gaiaeyes-media)" .; then
+            echo "::error ::Found old owner references. Replace with GaiaEyesHQ"; exit 1;
+          fi

--- a/ChatBotMasterTemplate.txt
+++ b/ChatBotMasterTemplate.txt
@@ -207,13 +207,13 @@ items = items[:limit]
 FB_ACCESS_TOKEN=EAALeprUm4HwBPDXpacqsvdr2H9dmjC3ZAbd33BzReDwI8KKMMH0Jy3Ju1lzmnit5nD20GZBGVrLa38lWBEXsZBBTrKHzIIQewbGqFfRZCaclI5UYjedrpO6wJqs4wZBJOr1oP510jiOq9dftnz9wjIDBJCbBmyRfCtUlI8UM49TvddQNtrvlzrQgsAth173ZAZBvkfxbH8z
 FB_PAGE_ID=772867052570153
 IG_USER_ID=17841476128531063
-MEDIA_CDN_BASE=https://cdn.jsdelivr.net/gh/gennwu/gaiaeyes-media/images
+MEDIA_CDN_BASE=https://cdn.jsdelivr.net/gh/GaiaEyesHQ/gaiaeyes-media@main/images
 SUPABASE_REST_URL=https://qadwzkwubfbfuslfxkzl.supabase.co/rest/v1
 SUPABASE_USER_ID=e20a3e9e-1fc2-41ad-b6f7-656668310d13
 GAIA_TIMEZONE=America/Chicago
 #Image hosting
-IG_STATIC_IMAGE_URL=https://gennwu.github.io/gaiaeyes-media/images/dailypost.jpg
-IG_IMAGE_BASE_URL=https://gennwu.github.io/gaiaeyes-media/images/
+IG_STATIC_IMAGE_URL=https://cdn.jsdelivr.net/gh/GaiaEyesHQ/gaiaeyes-media@main/images/dailypost.jpg
+IG_IMAGE_BASE_URL=https://cdn.jsdelivr.net/gh/GaiaEyesHQ/gaiaeyes-media@main/images/
 
 # === APIs ===
 NASA_API_KEY=aGYhKBDmeDfGFM2JkWg2lnCimJn5XgUmwM5UkB3d

--- a/bots/earthscope_post/gaia_eyes_viral_bot.py
+++ b/bots/earthscope_post/gaia_eyes_viral_bot.py
@@ -1432,7 +1432,7 @@ def build_payload(ts_iso_utc: str, kp: float, kp_time: Optional[str], sch: float
         "aqi": None,
         "aqi_city": None,
         "image_path": "images/dailypost.jpg",
-        "image_url_hint": "https://cdn.jsdelivr.net/gh/gennwu/gaiaeyes-media/images/dailypost.jpg",
+        "image_url_hint": "https://cdn.jsdelivr.net/gh/GaiaEyesHQ/gaiaeyes-media@main/images/dailypost.jpg",
         "commit_sha": commit_sha
     }
 

--- a/bots/earthscope_post/meta_poster.py
+++ b/bots/earthscope_post/meta_poster.py
@@ -29,7 +29,7 @@ load_dotenv(HERE.parent / ".env")
 SUPABASE_REST_URL   = os.getenv("SUPABASE_REST_URL", "").rstrip("/")
 SB_KEY              = os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_ANON_KEY")
 SB_USER_ID          = os.getenv("SUPABASE_USER_ID")
-MEDIA_CDN_BASE      = os.getenv("MEDIA_CDN_BASE", "https://cdn.jsdelivr.net/gh/gennwu/gaiaeyes-media/images").rstrip("/")
+MEDIA_CDN_BASE      = os.getenv("MEDIA_CDN_BASE", "https://cdn.jsdelivr.net/gh/GaiaEyesHQ/gaiaeyes-media@main/images").rstrip("/")
 
 FB_PAGE_ID          = os.getenv("FB_PAGE_ID")
 FB_ACCESS_TOKEN     = os.getenv("FB_ACCESS_TOKEN")

--- a/scripts/earthscope_rules_emit.py
+++ b/scripts/earthscope_rules_emit.py
@@ -47,8 +47,8 @@ def combine_schumann(sch):
             "f1_hz": round(combined,2), "primary": primary, "delta_hz": round(delta,2) if delta is not None else None
         },
         "sources": {
-            "cumiana": {"f1_hz": c_f1, "image": "https://gennwu.github.io/gaiaeyes-media/images/cumiana_latest.png"},
-            "tomsk":   {"f1_hz": t_f1, "image": "https://gennwu.github.io/gaiaeyes-media/images/tomsk_latest.png"}
+            "cumiana": {"f1_hz": c_f1, "image": "https://cdn.jsdelivr.net/gh/GaiaEyesHQ/gaiaeyes-media@main/images/cumiana_latest.png"},
+            "tomsk":   {"f1_hz": t_f1, "image": "https://cdn.jsdelivr.net/gh/GaiaEyesHQ/gaiaeyes-media@main/images/tomsk_latest.png"}
         }
     }
 

--- a/scripts/ingest_schumann_github.py
+++ b/scripts/ingest_schumann_github.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-Ingest Schumann now JSON from gennwu/gaiaeyes-media into ext.schumann (and stations/assets).
+Ingest Schumann now JSON from GaiaEyesHQ/gaiaeyes-media into ext.schumann (and stations/assets).
 
-JSON: https://raw.githubusercontent.com/gennwu/gaiaeyes-media/data/schumann_latest.json
+JSON: https://raw.githubusercontent.com/GaiaEyesHQ/gaiaeyes-media/data/schumann_latest.json
 
 - stations: 'tomsk', 'cumiana'
 - per station we ingest:
@@ -19,8 +19,8 @@ import os, sys, json, asyncio
 from datetime import datetime, timezone
 import asyncpg, httpx
 
-RAW_JSON = "https://raw.githubusercontent.com/gennwu/gaiaeyes-media/main/data/schumann_latest.json"
-RAW_IMG_BASE = "https://raw.githubusercontent.com/gennwu/gaiaeyes-media/main/images/"
+RAW_JSON = "https://raw.githubusercontent.com/GaiaEyesHQ/gaiaeyes-media/main/data/schumann_latest.json"
+RAW_IMG_BASE = "https://raw.githubusercontent.com/GaiaEyesHQ/gaiaeyes-media/main/images/"
 
 DB = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
 if not DB:
@@ -109,7 +109,7 @@ async def main():
                 # fallback: station-specific default
                 overlay_rel = f"{station_id}_overlay.png"
             overlay_url = RAW_IMG_BASE + overlay_rel
-            assets.append((overlay_url, "image/png", f"{station_id} overlay", json.dumps({"repo":"gennwu/gaiaeyes-media"})))
+            assets.append((overlay_url, "image/png", f"{station_id} overlay", json.dumps({"repo":"GaiaEyesHQ/gaiaeyes-media"})))
 
             # Timestamp
             ts = parse_ts(src.get("timestamp_utc")) or global_ts


### PR DESCRIPTION
## Summary
- update backend scripts and bot configuration to point to GaiaEyesHQ media URLs
- refresh documentation defaults for CDN and image links to use GaiaEyesHQ
- add a lint-links workflow that fails CI if deprecated gennwu references are committed

## Testing
- `curl -I https://cdn.jsdelivr.net/gh/GaiaEyesHQ/gaiaeyes-media@main/images/daily_caption.jpg` *(fails with HTTP 403 in CI sandbox)*
- `curl -fsSL https://gaiaeyeshq.github.io/gaiaeyes-media/data/earthscope_daily.json | head` *(fails with HTTP 403 in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68fb953d9d50832ab31d7612d7556d33