### PR TITLE
Fix lint-links workflow self-match

### DIFF
--- a/.github/workflows/lint-links.yml
+++ b/.github/workflows/lint-links.yml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Fail if old owner appears
         run: |
-          if grep -RIn --exclude-dir=.git -E "gennwu(|.github.io|/gaiaeyes-media)" .; then
+          if grep -RIn --exclude-dir=.git --exclude='.github/workflows/lint-links.yml' -E "gennwu(|.github.io|/gaiaeyes-media)" .; then
             echo "::error ::Found old owner references. Replace with GaiaEyesHQ"; exit 1;
           fi


### PR DESCRIPTION
## Summary
- exclude the lint-links workflow file from the grep search so the job no longer matches itself

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbac643d94832a9bcee88e95ccd47c