### PR TITLE
Fix lint workflow exclude pattern

### DIFF
--- a/.github/workflows/lint-links.yml
+++ b/.github/workflows/lint-links.yml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Fail if old owner appears
         run: |
-          if grep -RIn --exclude-dir=.git --exclude='.github/workflows/lint-links.yml' -E "gennwu(|.github.io|/gaiaeyes-media)" .; then
+          if grep -RIn --exclude-dir=.git --exclude='lint-links.yml' -E "gennwu(|.github.io|/gaiaeyes-media)" .; then
             echo "::error ::Found old owner references. Replace with GaiaEyesHQ"; exit 1;
           fi


### PR DESCRIPTION
## Summary
- update the lint-links workflow to ignore its own file when searching for legacy owner names

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fbae82faf8832a8294a3a12835da9f