### PR TITLE
Add space weather history builder and enhance compare views

### DIFF
--- a/.github/workflows/compare-series.yml
+++ b/.github/workflows/compare-series.yml
@@ -21,6 +21,17 @@ jobs:
           token: ${{ env.GAIAEYES_MEDIA_TOKEN }}
           path: gaiaeyes-media
 
+      - name: Build space_history.json
+        env:
+          SUPABASE_REST_URL: ${{ secrets.SUPABASE_REST_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          OUTPUT_JSON_PATH: ${{ github.workspace }}/gaiaeyes-media/data/space_history.json
+          HISTORY_DAYS: "365"
+          SW_DAILY_TABLE: "marts.space_weather_daily"
+          SW_DAILY_FIELDS: "day,kp_max_24h,bz_min,sw_speed_avg"
+        run: |
+          python3 scripts/build_space_history.py
+
       - name: Build compare_series.json
         env:
           MEDIA_DIR: ${{ github.workspace }}/gaiaeyes-media

--- a/scripts/build_compare_series.py
+++ b/scripts/build_compare_series.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python3
 """
-Build compare_series.json for overlay charts: quakes vs space-weather.
-Guaranteed series: m5p_daily from quakes_history.json.
-Optional: kp_daily_max, bz_daily_min, sw_daily_avg, flares, cme if sources exist later.
-
-Env:
-  MEDIA_DIR=/path/to/gaiaeyes-media
-  OUTPUT_JSON_PATH=.../gaiaeyes-media/data/compare_series.json
+Build compare_series.json for overlay charts comparing quakes and space-weather.
 """
-import os, sys, json, datetime as dt
+
+import datetime as dt
+import json
+import os
+
 
 def load_json(path):
     try:
@@ -17,39 +15,58 @@ def load_json(path):
     except Exception:
         return None
 
+
 def main():
     media_dir = os.getenv("MEDIA_DIR", "gaiaeyes-media")
-    out_path = os.getenv("OUTPUT_JSON_PATH", os.path.join(media_dir, "data", "compare_series.json"))
+    out_path = os.getenv(
+        "OUTPUT_JSON_PATH", os.path.join(media_dir, "data", "compare_series.json")
+    )
 
     qh = load_json(os.path.join(media_dir, "data", "quakes_history.json")) or {}
-    # Placeholder for future series sources:
-    # sh = load_json(os.path.join(media_dir, "data", "space_history.json")) or {}
-    # fc = load_json(os.path.join(media_dir, "data", "flares_history.json")) or {}
+    sh = load_json(os.path.join(media_dir, "data", "space_history.json")) or {}
+
+    qser = (qh.get("series") or {})
+    sser = (sh.get("series") or {})
 
     series = {}
+    series["all_daily"] = qser.get("all_daily", [])
+    series["m4p_daily"] = qser.get("m4p_daily", [])
+    series["m5p_daily"] = qser.get("m5p_daily", [])
+    series["m6p_daily"] = qser.get("m6p_daily", [])
+    series["m5p_monthly"] = qser.get("m5p_monthly", [])
+    series["m6p_monthly"] = qser.get("m6p_monthly", [])
+    series["kp_daily_max"] = sser.get("kp_daily_max", [])
+    series["bz_daily_min"] = sser.get("bz_daily_min", [])
+    series["sw_daily_avg"] = sser.get("sw_daily_avg", [])
 
-    # Quakes M5+ daily (always available once quakes_history is populated)
-    m5p_daily = (qh.get("series") or {}).get("m5p_daily") or []
-    series["m5p_daily"] = m5p_daily
-
-    # Hooks for future when you add space history:
-    # series["kp_daily_max"] = sh.get("series", {}).get("kp_daily_max", [])
-    # series["bz_daily_min"] = sh.get("series", {}).get("bz_daily_min", [])
-    # series["sw_daily_avg"] = sh.get("series", {}).get("sw_daily_avg", [])
-    # series["cme_daily_cnt"] = fc.get("series", {}).get("cme_daily_cnt", [])
-    # series["flares_m_count"] = fc.get("series", {}).get("flares_m_count", [])
+    labels = {
+        "all_daily": "Quakes (all, daily)",
+        "m4p_daily": "Quakes M4+ (daily)",
+        "m5p_daily": "Quakes M5+ (daily)",
+        "m6p_daily": "Quakes M6+ (daily)",
+        "m5p_monthly": "Quakes M5+ (monthly)",
+        "m6p_monthly": "Quakes M6+ (monthly)",
+        "kp_daily_max": "Kp (daily max)",
+        "bz_daily_min": "Bz (daily min, nT)",
+        "sw_daily_avg": "Solar wind (daily avg, km/s)",
+    }
 
     out = {
-        "timestamp_utc": dt.datetime.utcnow().replace(microsecond=0).isoformat().replace("+00:00","Z"),
+        "timestamp_utc": dt.datetime.utcnow()
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
         "series": series,
+        "labels": labels,
         "meta": {
-            "note": "Dates UTC. m5p_daily present by default. Space-weather series can be added as they become available."
-        }
+            "note": "Dates UTC. Use lag to explore timing; correlation is exploratory, not causal."
+        },
     }
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
     with open(out_path, "w", encoding="utf-8") as f:
-        f.write(json.dumps(out, ensure_ascii=False, separators=(",",":")))
-    print(f"[compare_series] wrote -> {out_path}")
+        f.write(json.dumps(out, ensure_ascii=False, separators=(",", ":")))
+    print("[compare_series] wrote ->", out_path)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/build_space_history.py
+++ b/scripts/build_space_history.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import os
+import json
+import datetime as dt
+import urllib.request
+import urllib.parse
+
+REST = os.getenv("SUPABASE_REST_URL", "").rstrip("/")
+KEY = os.getenv("SUPABASE_SERVICE_KEY", "") or os.getenv("SUPABASE_ANON_KEY", "")
+OUT = os.getenv("OUTPUT_JSON_PATH", "space_history.json")
+DAYS = int(os.getenv("HISTORY_DAYS", "365"))
+TABLE = os.getenv("SW_DAILY_TABLE", "marts.space_weather_daily")
+FIELDS = os.getenv("SW_DAILY_FIELDS", "day,kp_max_24h,bz_min,sw_speed_avg")
+
+
+def query_since(start_iso: str):
+    if not (REST and KEY):
+        return []
+    url = f"{REST}/{TABLE}?" + urllib.parse.urlencode({
+        "select": FIELDS,
+        "order": "day.asc",
+        "day": "gte." + start_iso,
+    })
+    req = urllib.request.Request(
+        url, headers={"apikey": KEY, "Authorization": "Bearer " + KEY}
+    )
+    with urllib.request.urlopen(req, timeout=45) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def main():
+    since = (dt.datetime.utcnow().date() - dt.timedelta(days=DAYS - 1)).isoformat()
+    rows = query_since(since)
+    kp, bz, sw = [], [], []
+    for r in rows:
+        d = r.get("day")
+        if not d:
+            continue
+        if r.get("kp_max_24h") is not None:
+            kp.append([d, float(r["kp_max_24h"])])
+        if r.get("bz_min") is not None:
+            bz.append([d, float(r["bz_min"])])
+        if r.get("sw_speed_avg") is not None:
+            sw.append([d, float(r["sw_speed_avg"])])
+    out = {
+        "timestamp_utc": dt.datetime.utcnow()
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "series": {
+            "kp_daily_max": kp,
+            "bz_daily_min": bz,
+            "sw_daily_avg": sw,
+        },
+    }
+    os.makedirs(os.path.dirname(OUT) or ".", exist_ok=True)
+    with open(OUT, "w", encoding="utf-8") as f:
+        f.write(json.dumps(out, ensure_ascii=False, separators=(",", ":")))
+    print("[space_history] wrote ->", OUT)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Supabase-backed builder for space weather history and call it from the compare-series workflow
- merge quake and space series with human-readable labels in `compare_series.json`
- surface friendly labels, responsive tweaks, and mobile polish in the compare and earthquake detail shortcodes

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_69041b6f418c832a85e689cddaf8f02a