### PR TITLE
feat: ingest and display space weather visuals

### DIFF
--- a/.github/workflows/space-visuals.yml
+++ b/.github/workflows/space-visuals.yml
@@ -1,0 +1,34 @@
+name: space-visuals
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout media repo
+        uses: actions/checkout@v4
+        with:
+          repository: GaiaEyesHQ/gaiaeyes-media
+          token: ${{ secrets.GAIAEYES_MEDIA_TOKEN }}
+          path: gaiaeyes-media
+      - name: Run space visuals ingest
+        env:
+          OUTPUT_JSON_PATH: ${{ github.workspace }}/gaiaeyes-media/data/space_live.json
+          MEDIA_DIR: ${{ github.workspace }}/gaiaeyes-media
+        run: |
+          python3 scripts/space_visuals_ingest.py
+      - name: Commit & push (images + space_live.json)
+        run: |
+          cd gaiaeyes-media
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add images/space/* data/space_live.json || true
+          if git diff --cached --quiet; then
+            echo "No changes."
+          else
+            git commit -m "chore: update space visuals & space_live.json [skip ci]"
+            git push
+          fi

--- a/scripts/space_visuals_ingest.py
+++ b/scripts/space_visuals_ingest.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+import os
+import json
+import datetime as dt
+import urllib.request
+
+OUT_JSON = os.getenv("OUTPUT_JSON_PATH", "space_live.json")
+MEDIA_DIR = os.getenv("MEDIA_DIR", "gaiaeyes-media")
+IMG_DIR = os.path.join(MEDIA_DIR, "images", "space")
+DATA_DIR = os.path.join(MEDIA_DIR, "data")
+os.makedirs(IMG_DIR, exist_ok=True)
+os.makedirs(DATA_DIR, exist_ok=True)
+
+
+def dl(url, dest):
+    try:
+        with urllib.request.urlopen(url, timeout=30) as r:
+            with open(dest, "wb") as f:
+                f.write(r.read())
+        return True
+    except Exception as e:
+        print(f"[dl] {url} -> {e}")
+        return False
+
+
+def fetch_json(url):
+    try:
+        with urllib.request.urlopen(url, timeout=30) as r:
+            return json.loads(r.read().decode("utf-8"))
+    except Exception as e:
+        print(f"[json] {url} -> {e}")
+        return None
+
+
+def main():
+    # 1) GOES SUVI (131Å) + Solar flares (XRS) + Proton flux (GOES)
+    suvi_latest = "https://services.swpc.noaa.gov/images/animations/suvi/primary/131/latest.jpg"
+    xrs_7d = "https://services.swpc.noaa.gov/json/goes/primary/xrays-7-day.json"
+    protons_7d = "https://services.swpc.noaa.gov/json/goes/primary/integral-protons-7-day.json"
+
+    # 2) Aurora (Ovation) maps (NH/SH)
+    ov_nh = "https://services.swpc.noaa.gov/images/aurora-forecast-northern-hemisphere.jpg"
+    ov_sh = "https://services.swpc.noaa.gov/images/aurora-forecast-southern-hemisphere.jpg"
+
+    # 3) CME coronagraph imagery (SOHO C2 & GOES CCOR-1)
+    soho_c2 = "https://soho.nascom.nasa.gov/data/realtime/c2/1024/latest.jpg"
+    goes_cc1 = "https://services.swpc.noaa.gov/images/goes-ccor1/latest.jpg"
+
+    # 4) HMI intensitygram (sunspot context). If you prefer SDO AIA 193Å (coronal holes), swap a stable endpoint later.
+    hmi_img = "https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_HMIIC.jpg"
+
+    # 5) Magnetometer plots (Kiruna/CANMOS/Hobart) — replace with your preferred latest endpoints if you have better sources
+    kiruna = "https://www.irf.se/Observatory/?download=magplot&site=kir"
+    canmos = "https://www.spaceweather.gc.ca/auto_generated_products/magnetometers/013.png"
+    hobart = "https://www.sws.bom.gov.au/Images/HF%20Systems/IPS%20Magnetometer%20Data/Hobart.png"
+
+    stamp = dt.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    imgs = {
+        "suvi_131_latest": ("suvi_131_latest.jpg", suvi_latest),
+        "ovation_nh": (f"ovation_nh_{stamp}.jpg", ov_nh),
+        "ovation_sh": (f"ovation_sh_{stamp}.jpg", ov_sh),
+        "soho_c2": (f"soho_c2_{stamp}.jpg", soho_c2),
+        "goes_ccor1": (f"goes_ccor1_{stamp}.jpg", goes_cc1),
+        "hmi_intensity": (f"hmi_intensity_{stamp}.jpg", hmi_img),
+        "mag_kiruna": (f"mag_kiruna_{stamp}.png", kiruna),
+        "mag_canmos": (f"mag_canmos_{stamp}.png", canmos),
+        "mag_hobart": (f"mag_hobart_{stamp}.png", hobart),
+    }
+    saved = {}
+    for key, (fn, url) in imgs.items():
+        dest = os.path.join(IMG_DIR, fn)
+        if dl(url, dest):
+            saved[key] = f"images/space/{fn}"
+
+    xrs = fetch_json(xrs_7d) or []
+    p7d = fetch_json(protons_7d) or []
+
+    out = {
+        "timestamp_utc": dt.datetime.utcnow().replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "images": saved,
+        "series": {
+            "xrs_7d": xrs,
+            "protons_7d": p7d,
+        },
+        "notes": "Visuals cached for detail pages. Use with [gaia_space_visuals] or [gaia_space_detail].",
+    }
+
+    with open(OUT_JSON if os.path.isabs(OUT_JSON) else os.path.join(MEDIA_DIR, OUT_JSON), "w", encoding="utf-8") as f:
+        f.write(json.dumps(out, ensure_ascii=False, separators=(",", ":")))
+    print("[space_visuals] wrote images and space_live.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/wp-content/mu-plugins/gaiaeyes-space-visuals.php
+++ b/wp-content/mu-plugins/gaiaeyes-space-visuals.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Plugin Name: Gaia Eyes – Space Visuals
+ * Description: Renders Solar/Aurora visual panels using gaiaeyes-media/data/space_live.json + images/space/.
+ * Version: 1.0.0
+ */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function ge_fetch_json_cached($url, $cache_min) {
+    $ttl = max(1, intval($cache_min)) * MINUTE_IN_SECONDS;
+    $key = 'ge_json_' . md5($url);
+    $cached = get_transient($key);
+    if ($cached === false) {
+        $response = wp_remote_get(esc_url_raw($url), [
+            'timeout' => 8,
+            'headers' => ['Accept' => 'application/json'],
+        ]);
+        if (!is_wp_error($response) && wp_remote_retrieve_response_code($response) === 200) {
+            $cached = json_decode(wp_remote_retrieve_body($response), true);
+            set_transient($key, $cached, $ttl);
+        }
+    }
+
+    return is_array($cached) ? $cached : null;
+}
+
+add_shortcode('gaia_space_visuals', function ($atts) {
+    $atts = shortcode_atts([
+        'url' => 'https://gaiaeyeshq.github.io/gaiaeyes-media/data/space_live.json',
+        'cache' => 10,
+    ], $atts, 'gaia_space_visuals');
+
+    $data = ge_fetch_json_cached($atts['url'], $atts['cache']);
+    if (!$data) {
+        return '<div class="ge-card">Space visuals unavailable.</div>';
+    }
+
+    $images = isset($data['images']) ? $data['images'] : [];
+
+    ob_start();
+    ?>
+    <section class="ge-panel ge-space">
+      <div class="ge-grid">
+        <article class="ge-card"><h3>Solar disc (SUVI 131Å)</h3>
+          <?php if (!empty($images['suvi_131_latest'])) : ?>
+            <img src="https://gaiaeyeshq.github.io/gaiaeyes-media/<?php echo esc_attr($images['suvi_131_latest']); ?>" alt="GOES SUVI 131 latest" />
+          <?php endif; ?>
+        </article>
+        <article class="ge-card"><h3>Auroral Ovals</h3><div class="ov-grid">
+          <?php if (!empty($images['ovation_nh'])) : ?><figure><img src="https://gaiaeyeshq.github.io/gaiaeyes-media/<?php echo esc_attr($images['ovation_nh']); ?>" alt="Aurora NH" /><figcaption>NH forecast</figcaption></figure><?php endif; ?>
+          <?php if (!empty($images['ovation_sh'])) : ?><figure><img src="https://gaiaeyeshq.github.io/gaiaeyes-media/<?php echo esc_attr($images['ovation_sh']); ?>" alt="Aurora SH" /><figcaption>SH forecast</figcaption></figure><?php endif; ?>
+        </div></article>
+        <article class="ge-card"><h3>Coronagraph / CMEs</h3><div class="ov-grid">
+          <?php if (!empty($images['soho_c2'])) : ?><figure><img src="https://gaiaeyeshq.github.io/gaiaeyes-media/<?php echo esc_attr($images['soho_c2']); ?>" alt="SOHO C2 latest" /><figcaption>SOHO C2</figcaption></figure><?php endif; ?>
+          <?php if (!empty($images['goes_ccor1'])) : ?><figure><img src="https://gaiaeyeshq.github.io/gaiaeyes-media/<?php echo esc_attr($images['goes_ccor1']); ?>" alt="GOES CCOR-1 latest" /><figcaption>GOES CCOR-1</figcaption></figure><?php endif; ?>
+        </div></article>
+        <article class="ge-card"><h3>Magnetometers</h3><div class="ov-grid">
+          <?php foreach ([
+            'mag_kiruna' => 'Kiruna',
+            'mag_canmos' => 'CANMOS',
+            'mag_hobart' => 'Hobart',
+          ] as $key => $caption) :
+            if (!empty($images[$key])) : ?>
+              <figure><img src="https://gaiaeyeshq.github.io/gaiaeyes-media/<?php echo esc_attr($images[$key]); ?>" alt="Magnetometer <?php echo esc_attr($caption); ?>" /><figcaption><?php echo esc_html($caption); ?></figcaption></figure>
+            <?php endif;
+          endforeach; ?>
+        </div></article>
+        <article class="ge-card"><h3>Sunspots / HMI</h3>
+          <?php if (!empty($images['hmi_intensity'])) : ?>
+            <img src="https://gaiaeyeshq.github.io/gaiaeyes-media/<?php echo esc_attr($images['hmi_intensity']); ?>" alt="HMI Intensitygram latest" />
+          <?php endif; ?>
+        </article>
+      </div>
+      <style>
+        .ge-space .ge-grid { display:grid; gap:12px; }
+        @media (min-width:900px) { .ge-space .ge-grid { grid-template-columns:repeat(2,1fr); } }
+        .ge-space img { width:100%; height:auto; border-radius:8px; border:1px solid rgba(255,255,255,.08); }
+        .ov-grid { display:grid; gap:8px; }
+        @media (min-width:640px) { .ov-grid { grid-template-columns:repeat(2,1fr); } }
+        figure { margin:0; }
+        figcaption { text-align:center; font-size:.85rem; opacity:.85; margin-top:4px; }
+      </style>
+    </section>
+    <?php
+    return ob_get_clean();
+});
+
+add_shortcode('gaia_space_detail', function ($atts) {
+    $atts = shortcode_atts([
+        'cache' => 5,
+        'url' => 'https://gaiaeyeshq.github.io/gaiaeyes-media/data/space_live.json',
+    ], $atts, 'gaia_space_detail');
+
+    return do_shortcode('[gaia_space_visuals url="' . esc_url($atts['url']) . '" cache="' . esc_attr($atts['cache']) . '"]');
+});


### PR DESCRIPTION
## Summary
- add a space-visuals ingestion script that caches imagery and series data into the media repo
- schedule a GitHub Action to refresh the media artifacts twice an hour
- add a WordPress MU-plugin shortcode that renders the space weather visuals grid

## Testing
- python -m compileall scripts/space_visuals_ingest.py
- php -l wp-content/mu-plugins/gaiaeyes-space-visuals.php

------
https://chatgpt.com/codex/tasks/task_e_6905162ea7fc832a83e5d968c1c0bade