### PR TITLE
feat: add automated space news ingestion

### DIFF
--- a/.github/workflows/news-ingest.yml
+++ b/.github/workflows/news-ingest.yml
@@ -1,0 +1,30 @@
+name: news-ingest
+on:
+  schedule:
+    - cron: "25 5 * * *"
+  workflow_dispatch: {}
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout media repo
+        uses: actions/checkout@v4
+        with:
+          repository: GaiaEyesHQ/gaiaeyes-media
+          token: ${{ secrets.GAIAEYES_MEDIA_TOKEN }}
+          path: gaiaeyes-media
+      - name: Build news (30-day backfill)
+        env:
+          MEDIA_DIR: ${{ github.workspace }}/gaiaeyes-media
+          OUTPUT_JSON_PATH: ${{ github.workspace }}/gaiaeyes-media/data/news_latest.json
+          LOOKBACK_DAYS: "30"
+        run: |
+          python3 scripts/ingest_space_news.py
+      - name: Commit & push
+        run: |
+          cd gaiaeyes-media
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/news_latest.json
+          if git diff --cached --quiet; then echo "No changes."; else git commit -m "chore: news_latest.json [skip ci]" && git push; fi

--- a/scripts/ingest_space_news.py
+++ b/scripts/ingest_space_news.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+import datetime as dt
+import json
+import os
+import urllib.request
+from email.utils import parsedate_to_datetime
+
+OUT_JSON = os.getenv("OUTPUT_JSON_PATH", "news_latest.json")
+MEDIA_DIR = os.getenv("MEDIA_DIR", "gaiaeyes-media")
+LOOKBACK = int(os.getenv("LOOKBACK_DAYS", "30"))
+
+SOURCES = [
+  ("NOAA SWPC News", "https://services.swpc.noaa.gov/news/notifications.rss", "space_weather"),
+  ("NASA Heliophysics", "https://www.nasa.gov/rss/dyn/solar_system.rss", "solar_activity"),
+]
+
+
+def fetch(url: str) -> str:
+  try:
+    with urllib.request.urlopen(url, timeout=20) as r:
+      return r.read().decode("utf-8", "ignore")
+  except Exception as e:  # pragma: no cover - network resiliency
+    print("[news]", url, e)
+    return ""
+
+
+def rss_items(raw: str):
+  if not raw:
+    return []
+  out = []
+  chunks = raw.split("<item>")
+  for frag in chunks[1:]:
+    title = frag.split("</title>")[0].split("<title>")[-1].strip()
+    link = frag.split("</link>")[0].split("<link>")[-1].strip()
+    pub = ""
+    if "</pubDate>" in frag:
+      pub = frag.split("</pubDate>")[0].split("<pubDate>")[-1].strip()
+    out.append({"title": title, "link": link, "published_at": pub})
+  return out
+
+
+def parse_pubdate(value: str):
+  if not value:
+    return None
+  try:
+    parsed = parsedate_to_datetime(value)
+  except (TypeError, ValueError):
+    return None
+  if parsed is None:
+    return None
+  if parsed.tzinfo is None:
+    parsed = parsed.replace(tzinfo=dt.timezone.utc)
+  return parsed.astimezone(dt.timezone.utc)
+
+
+def output_path() -> str:
+  if os.path.isabs(OUT_JSON):
+    return OUT_JSON
+  return os.path.join(MEDIA_DIR, "data", OUT_JSON)
+
+
+def main():
+  now = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
+  cutoff = now - dt.timedelta(days=max(0, LOOKBACK))
+  items = []
+  for name, url, cat in SOURCES:
+    raw = fetch(url)
+    for it in rss_items(raw):
+      it["source"] = name
+      it["category"] = cat
+      parsed = parse_pubdate(it.get("published_at"))
+      if parsed:
+        if parsed < cutoff:
+          continue
+        it["published_at"] = parsed.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        it["_dt"] = parsed
+      else:
+        it["published_at"] = ""
+        it["_dt"] = now
+      items.append(it)
+
+  seen = set()
+  deduped = []
+  for it in items:
+    link = it.get("link")
+    if not link or link in seen:
+      continue
+    seen.add(link)
+    deduped.append(it)
+
+  deduped.sort(key=lambda x: x.get("_dt") or dt.datetime.min.replace(tzinfo=dt.timezone.utc), reverse=True)
+  for it in deduped:
+    it.pop("_dt", None)
+
+  dest = output_path()
+  os.makedirs(os.path.dirname(dest), exist_ok=True)
+  payload = {
+    "timestamp_utc": now.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    "items": deduped,
+  }
+  with open(dest, "w", encoding="utf-8") as f:
+    json.dump(payload, f, ensure_ascii=False, separators=(",", ":"))
+  print("[news] wrote", dest, "with", len(deduped), "items")
+
+
+if __name__ == "__main__":
+  main()

--- a/wp-content/mu-plugins/gaiaeyes-news.php
+++ b/wp-content/mu-plugins/gaiaeyes-news.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Plugin Name: Gaia Eyes – News
+ * Description: Shows latest space/aurora headlines from gaiaeyes-media/data/news_latest.json.
+ */
+if (!defined('ABSPATH')) {
+  exit;
+}
+
+function ge_news_cached($url, $cache_min) {
+  $ttl = max(1, intval($cache_min)) * MINUTE_IN_SECONDS;
+  $cache_key = 'ge_news_' . md5($url);
+  $payload = get_transient($cache_key);
+  if ($payload === false) {
+    $response = wp_remote_get(esc_url_raw($url), [
+      'timeout' => 8,
+      'headers' => ['Accept' => 'application/json'],
+    ]);
+    if (!is_wp_error($response) && wp_remote_retrieve_response_code($response) === 200) {
+      $payload = json_decode(wp_remote_retrieve_body($response), true);
+      if (is_array($payload)) {
+        set_transient($cache_key, $payload, $ttl);
+      }
+    }
+  }
+  return is_array($payload) ? $payload : null;
+}
+
+add_shortcode('gaia_news', function ($atts) {
+  $atts = shortcode_atts([
+    'url' => 'https://gaiaeyeshq.github.io/gaiaeyes-media/data/news_latest.json',
+    'cache' => 30,
+    'limit' => 12,
+  ], $atts, 'gaia_news');
+
+  $json = ge_news_cached($atts['url'], $atts['cache']);
+  if (!$json || empty($json['items']) || !is_array($json['items'])) {
+    return '<div class="ge-card">No news.</div>';
+  }
+
+  $limit = max(1, intval($atts['limit']));
+  $items = array_slice($json['items'], 0, $limit);
+  ob_start();
+  ?>
+  <section class="ge-panel ge-news">
+    <div class="ge-grid">
+      <?php foreach ($items as $item): ?>
+        <article class="ge-card">
+          <h3><a class="gaia-link" href="<?php echo esc_url($item['link'] ?? '#'); ?>" target="_blank" rel="noopener"><?php echo esc_html($item['title'] ?? ''); ?></a></h3>
+          <?php if (!empty($item['source']) || !empty($item['published_at'])): ?>
+            <div class="ge-meta"><?php echo esc_html(trim(($item['source'] ?? '') . (!empty($item['published_at']) ? ' • ' . $item['published_at'] : ''))); ?></div>
+          <?php endif; ?>
+        </article>
+      <?php endforeach; ?>
+    </div>
+    <style>
+      .ge-news .ge-grid { display: grid; gap: 12px; }
+      @media (min-width: 900px) { .ge-news .ge-grid { grid-template-columns: repeat(3, 1fr); } }
+      .ge-news .ge-meta { opacity: .8; font-size: .9rem; margin-top: 4px; }
+      .gaia-link { color: inherit; text-decoration: none; border-bottom: 1px dotted rgba(255, 255, 255, .25); }
+      .gaia-link:hover { border-bottom-color: rgba(255, 255, 255, .6); }
+    </style>
+  </section>
+  <?php
+  return ob_get_clean();
+});


### PR DESCRIPTION
## Summary
- add a space news ingestion script that deduplicates items, enforces a 30-day lookback, and emits JSON
- schedule a GitHub Action to publish the refreshed feed to the gaiaeyes-media repository each day
- add a WordPress MU plugin shortcode for rendering the published headlines on the site

## Testing
- python3 -m compileall scripts/ingest_space_news.py

------
https://chatgpt.com/codex/tasks/task_e_69052b180444832ab5081d25df620521