### PR TITLE
Fix psycopg prepared statement pool conflict

### DIFF
--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -43,7 +43,11 @@ async def get_pool() -> AsyncConnectionPool:
             timeout=30,
             open=False,  # lazy
             kwargs={
-                "prepare_threshold": 0,  # NEVER prepare (PgBouncer-safe)
+                # Disable server-side prepared statements.
+                # Psycopg interprets ``prepare_threshold=None`` as "never prepare",
+                # whereas ``0`` actually forces immediate preparation and can trigger
+                # DuplicatePreparedStatement errors when connections are pooled.
+                "prepare_threshold": None,
                 "connect_timeout": 10,
             },
         )


### PR DESCRIPTION
## Summary
- update the async connection pool to disable server-side prepared statements
- add documentation on why prepare_threshold must be None to avoid duplicate prepared statements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690972494320832a8d98c381fc97726e