### PR TITLE
Normalize symptom codes and add lookup endpoint

### DIFF
--- a/docs/symptoms_api.md
+++ b/docs/symptoms_api.md
@@ -29,6 +29,23 @@ the service automatically stamps the current UTC time.
 }
 ```
 
+**Normalization rules**
+
+- Incoming codes are normalized before insert: trim whitespace, replace spaces/dashes
+  with underscores, and uppercase the result (e.g., `"nerve pain" → "NERVE_PAIN"`).
+- If the normalized value does not exist in `dim.symptom_codes`, the service maps it
+  to `OTHER` (assuming the catalog contains an `OTHER` entry).
+- Opt-in validation: pass `?strict=1` to reject unknown codes instead of mapping.
+  The server responds with HTTP 400 and a payload of the form:
+
+  ```json
+  {
+    "ok": false,
+    "error": "unknown symptom_code",
+    "valid": ["HEADACHE", "NERVE_PAIN", "OTHER", ...]
+  }
+  ```
+
 **Successful response**
 
 ```json
@@ -37,6 +54,32 @@ the service automatically stamps the current UTC time.
   "id": "7f3e85b1-67d6-4f83-9d63-2a0f1c0e7f6e",
   "ts_utc": "2024-04-02T14:18:00+00:00"
 }
+```
+
+## GET `/v1/symptoms/codes`
+
+Returns the catalog of symptom codes from `dim.symptom_codes` ordered by label.
+Codes in the response are normalized to the uppercase underscore format so clients
+can reuse them directly when posting events. Responses include a short cache header
+(`Cache-Control: public, max-age=300`).
+
+**Response**
+
+```json
+[
+  {
+    "symptom_code": "HEADACHE",
+    "label": "Headache",
+    "description": "Headache or migraine",
+    "is_active": true
+  },
+  {
+    "symptom_code": "NERVE_PAIN",
+    "label": "Nerve pain",
+    "description": "Pins/needles, burning, or nerve pain",
+    "is_active": true
+  }
+]
 ```
 
 ## GET `/v1/symptoms/today`

--- a/sql/2025_11xx_symptom_normalize_trigger.sql
+++ b/sql/2025_11xx_symptom_normalize_trigger.sql
@@ -1,0 +1,29 @@
+-- Optional safeguard to keep raw.user_symptom_events normalized.
+-- This script only creates the trigger function. Enable the trigger manually in
+-- Supabase Studio (SQL editor) once you are ready.
+
+begin;
+
+create schema if not exists raw;
+
+create or replace function raw.tg_normalize_symptom_code()
+returns trigger
+language plpgsql
+as $$
+begin
+    new.symptom_code := upper(replace(replace(new.symptom_code, '-', '_'), ' ', '_'));
+    return new;
+end;
+$$;
+
+drop trigger if exists trg_normalize_symptom_code on raw.user_symptom_events;
+
+-- To enable the trigger, run the statement below in Supabase Studio after
+-- reviewing:
+-- create trigger trg_normalize_symptom_code
+--     before insert or update
+--     on raw.user_symptom_events
+--     for each row
+--     execute function raw.tg_normalize_symptom_code();
+
+commit;

--- a/tests/test_symptoms_normalize.py
+++ b/tests/test_symptoms_normalize.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ROOT = Path(__file__).resolve().parents[1]
+import sys
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.main import app  # noqa: E402
+from app.db import get_db, symptoms as symptoms_db  # noqa: E402
+
+UTC = timezone.utc
+
+
+class RecordingStore:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+        self.counter = 0
+
+    def insert(
+        self,
+        user_id: str,
+        *,
+        symptom_code: str,
+        ts_utc: Optional[datetime] = None,
+        severity: Optional[int] = None,
+        free_text: Optional[str] = None,
+        tags: Optional[Iterable[str]] = None,
+    ) -> dict:
+        self.counter += 1
+        ts_value = ts_utc
+        if ts_value is None:
+            ts_value = datetime(2024, 1, 1, tzinfo=UTC)
+        elif ts_value.tzinfo is None:
+            ts_value = ts_value.replace(tzinfo=UTC)
+        else:
+            ts_value = ts_value.astimezone(UTC)
+        event = {
+            "id": f"evt-{self.counter}",
+            "user_id": user_id,
+            "symptom_code": symptom_code,
+            "ts_utc": ts_value,
+            "severity": severity,
+            "free_text": free_text,
+            "tags": list(tags or []),
+        }
+        self.events.append(event)
+        return {"id": event["id"], "ts_utc": ts_value.isoformat()}
+
+
+@pytest.fixture(autouse=True)
+def override_dev_bearer():
+    from app import db
+
+    original = db.settings.DEV_BEARER
+    db.settings.DEV_BEARER = "test-token"
+    try:
+        yield
+    finally:
+        db.settings.DEV_BEARER = original
+
+
+@pytest.fixture(autouse=True)
+def override_db_dependency():
+    async def _fake_db():
+        yield object()
+
+    app.dependency_overrides[get_db] = _fake_db
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def recording_store(monkeypatch):
+    store = RecordingStore()
+
+    async def _insert(conn, user_id, **kwargs):  # noqa: ARG001
+        return store.insert(user_id, **kwargs)
+
+    async def _codes(conn, include_inactive=True):  # noqa: ARG001
+        return [
+            {
+                "symptom_code": "NERVE_PAIN",
+                "label": "Nerve pain",
+                "description": None,
+                "is_active": True,
+            },
+            {
+                "symptom_code": "OTHER",
+                "label": "Other",
+                "description": None,
+                "is_active": True,
+            },
+        ]
+
+    monkeypatch.setattr(symptoms_db, "insert_symptom_event", _insert)
+    monkeypatch.setattr(symptoms_db, "fetch_symptom_codes", _codes)
+
+    return store
+
+
+@pytest.mark.anyio
+async def test_normalizes_variants(client: AsyncClient, recording_store: RecordingStore):
+    headers = {
+        "Authorization": "Bearer test-token",
+        "X-Dev-UserId": "00000000-0000-0000-0000-000000000001",
+    }
+
+    payload = {"symptom_code": "nerve pain"}
+    response = await client.post("/v1/symptoms", json=payload, headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert recording_store.events[0]["symptom_code"] == "NERVE_PAIN"
+
+    payload_dash = {"symptom_code": "nerve-pain"}
+    response_dash = await client.post("/v1/symptoms", json=payload_dash, headers=headers)
+    assert response_dash.status_code == 200
+    assert recording_store.events[1]["symptom_code"] == "NERVE_PAIN"
+
+
+@pytest.mark.anyio
+async def test_unknown_strict_vs_default(client: AsyncClient, recording_store: RecordingStore):
+    headers = {
+        "Authorization": "Bearer test-token",
+        "X-Dev-UserId": "00000000-0000-0000-0000-000000000002",
+    }
+
+    strict_response = await client.post(
+        "/v1/symptoms?strict=1",
+        json={"symptom_code": "mystery"},
+        headers=headers,
+    )
+    assert strict_response.status_code == 400
+    strict_data = strict_response.json()
+    assert strict_data["ok"] is False
+    assert strict_data["error"] == "unknown symptom_code"
+    assert "valid" in strict_data and "NERVE_PAIN" in strict_data["valid"]
+    assert not recording_store.events
+
+    relaxed_response = await client.post(
+        "/v1/symptoms",
+        json={"symptom_code": "mystery"},
+        headers=headers,
+    )
+    assert relaxed_response.status_code == 200
+    relaxed_data = relaxed_response.json()
+    assert relaxed_data["ok"] is True
+    assert recording_store.events[0]["symptom_code"] == "OTHER"


### PR DESCRIPTION
## Summary
- normalize inbound symptom codes, add strict mode validation, and log key diagnostics
- expose `/v1/symptoms/codes` for clients and document the normalization behaviour
- cover the workflow with tests, add optional SQL trigger helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69098c6dcb70832aa289eb40277e805b