### PR TITLE
Harden DB pool and normalize API envelopes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from fastapi import FastAPI, Depends, Request
@@ -23,7 +24,7 @@ except ModuleNotFoundError:
     except ModuleNotFoundError:
         webhooks_router = None
 from .utils.auth import require_auth as ensure_authenticated
-from .db import get_pool
+from .db import get_pool, open_pool, close_pool
 
 
 logger = logging.getLogger(__name__)
@@ -55,6 +56,11 @@ async def _log_routes():
 
 
 @app.on_event("startup")
+async def _open_pool():
+    await open_pool()
+
+
+@app.on_event("startup")
 async def _check_db_ready():
     try:
         pool = await get_pool()
@@ -65,6 +71,11 @@ async def _check_db_ready():
         logger.info("[DB] ready")
     except Exception as exc:  # pragma: no cover - startup diagnostics
         logger.exception("[DB] startup check failed: %s", exc)
+
+
+@app.on_event("shutdown")
+async def _close_pool():
+    await close_pool()
 
 # Build marker for health checks (update per deploy or wire to your CI SHA)
 BUILD = "2025-09-20T02:45Z"
@@ -82,13 +93,29 @@ if WebhookSigMiddleware is not None:
     app.add_middleware(WebhookSigMiddleware)
 
 
+async def _health_db_probe() -> bool:
+    try:
+        async def _probe() -> bool:
+            pool = await get_pool()
+            async with pool.connection() as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute("select 1;")
+                    await cur.fetchone()
+            return True
+
+        return await asyncio.wait_for(_probe(), timeout=0.3)
+    except Exception:
+        return False
+
+
 @app.get("/health")
 async def health():
     return {
         "ok": True,
         "service": "gaiaeyes-backend",
         "build": BUILD,
-        "time": datetime.now(timezone.utc).isoformat()
+        "time": datetime.now(timezone.utc).isoformat(),
+        "db": await _health_db_probe(),
     }
 
 # ---- Simple bearer auth for /v1/*

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,19 @@
+# Operations Runbook
+
+## Supabase configuration
+- Set **POOL_MODE=transaction** for the project's pgBouncer configuration when using async clients.
+- Keep the project in the "Running" state; paused projects will close existing connections and cause client pool churn.
+- Tune pgBouncer `idle_timeout` to be at least 60 seconds so short gaps in traffic do not recycle connections immediately.
+
+## Render environment
+- `DATABASE_URL` should target the pgBouncer endpoint on port **6543** and include `sslmode=require` in the query string.
+- Restarting the service will automatically reopen the shared async connection pool during FastAPI startup.
+
+## Connectivity checks
+Run the following from a Render shell or any environment that has network access to Supabase:
+
+```bash
+psql "$DATABASE_URL" -c "select now()"
+```
+
+A successful response confirms the credentials, pgBouncer endpoint, and SSL settings are all valid.

--- a/tests/api/test_symptoms.py
+++ b/tests/api/test_symptoms.py
@@ -245,8 +245,10 @@ async def test_daily_aggregation_flow(client: AsyncClient, fake_store: FakeSympt
         assert response.status_code == 200
         data = response.json()
         assert data["ok"] is True
-        assert "id" in data
-        assert data["ts_utc"].endswith("Z") or data["ts_utc"].endswith("+00:00")
+        assert data.get("error") is None
+        assert data.get("data") is not None
+        assert "id" in data["data"]
+        assert data["data"]["ts_utc"].endswith("Z") or data["data"]["ts_utc"].endswith("+00:00")
 
     today = await client.get("/v1/symptoms/today", headers=headers)
     assert today.status_code == 200

--- a/tests/test_symptoms_normalize.py
+++ b/tests/test_symptoms_normalize.py
@@ -172,12 +172,12 @@ async def test_unknown_strict_vs_default(client: AsyncClient, recording_store: R
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "path, attr, expected_error",
+    "path, attr",
     [
-        ("/v1/symptoms/codes", "fetch_symptom_codes", "Failed to load symptom codes"),
-        ("/v1/symptoms/today", "fetch_symptoms_today", "Failed to load today's symptoms"),
-        ("/v1/symptoms/daily", "fetch_daily_summary", "Failed to load daily symptom summary"),
-        ("/v1/symptoms/diag", "fetch_diagnostics", "Failed to load diagnostic summary"),
+        ("/v1/symptoms/codes", "fetch_symptom_codes"),
+        ("/v1/symptoms/today", "fetch_symptoms_today"),
+        ("/v1/symptoms/daily", "fetch_daily_summary"),
+        ("/v1/symptoms/diag", "fetch_diagnostics"),
     ],
 )
 async def test_symptom_routes_wrap_db_errors(
@@ -185,7 +185,6 @@ async def test_symptom_routes_wrap_db_errors(
     monkeypatch: pytest.MonkeyPatch,
     path: str,
     attr: str,
-    expected_error: str,
 ):
     async def _boom(*args, **kwargs):  # noqa: ARG001
         raise RuntimeError("db boom")
@@ -202,7 +201,7 @@ async def test_symptom_routes_wrap_db_errors(
     payload = response.json()
     assert payload["ok"] is False
     assert payload["data"] == []
-    assert payload["error"] == expected_error
+    assert payload["error"] == "db boom"
 
 
 @pytest.mark.anyio
@@ -222,4 +221,4 @@ async def test_post_symptom_returns_normalized_error(client: AsyncClient, monkey
     payload = response.json()
     assert payload["ok"] is False
     assert payload["data"] is None
-    assert payload["error"] == "Failed to load symptom codes"
+    assert payload["error"] == "no db"


### PR DESCRIPTION
## Summary
- configure a shared async psycopg pool tuned for Supabase pgBouncer, run readiness probes on startup, and expose pool stats via `/v1/diag/db`
- normalize feature and symptom routes to always return `{ok,data,error}` envelopes and surface database errors without throwing
- document Supabase connection expectations and update API tests for the new response shapes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_69099b1ccdb0832a9128bf66e37be25d