### PR TITLE
Improve db pool resilience and batch ingestion reliability

### DIFF
--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -3,15 +3,19 @@ from __future__ import annotations
 
 import asyncio
 from datetime import date, datetime
-from typing import Annotated, Awaitable, Dict, List, Optional, Union, Callable
+from typing import Annotated, Awaitable, Dict, List, Optional, Union, Callable, Tuple, Any
 
 import math
-from psycopg import errors as pg_errors
+from collections import deque
+from psycopg import errors as pg_errors, OperationalError
+from psycopg_pool.errors import PoolTimeout
 
 from fastapi import APIRouter, Body, Depends, Request, Header, HTTPException, status, Query
 from pydantic import BaseModel
 
 from ..db import get_pool, settings  # settings.DEV_BEARER, async pg pool
+from . import summary as _summary_module
+from .summary import mart_refresh
 
 from zoneinfo import ZoneInfo
 from os import getenv
@@ -22,12 +26,33 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["ingest"])
 
 DEFAULT_TIMEZONE = "America/Chicago"
-REFRESH_DEBOUNCE_SECONDS = 60.0
 REFRESH_DISABLED = getenv("MART_REFRESH_DISABLE", "0").lower() in {"1", "true", "yes", "on"}
 
-_refresh_registry: Dict[str, float] = {}
-_refresh_lock = asyncio.Lock()
-_refresh_task_factory: Callable[[Awaitable[None]], asyncio.Task] = asyncio.create_task
+_backlog = deque()
+_backlog_lock = asyncio.Lock()
+_backlog_drain_lock = asyncio.Lock()
+_backlog_task_factory: Callable[[Awaitable[None]], asyncio.Task] = asyncio.create_task
+
+# Legacy compatibility for tests expecting direct access to the refresh registry
+_refresh_registry = _summary_module._refresh_registry
+_refresh_task_factory = _summary_module._refresh_task_factory
+
+
+async def _execute_refresh(user_id: str, day_local: date) -> None:
+    await _summary_module._execute_mart_refresh(user_id, day_local)
+
+
+class BatchInsertError(Exception):
+    def __init__(self, reason: str, exc: Optional[BaseException] = None) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.exc = exc
+
+
+def _sample_to_dict(sample: SampleIn) -> Dict[str, Any]:
+    if hasattr(sample, "model_dump"):
+        return sample.model_dump()
+    return sample.dict()
 
 
 def _resolve_timezone(value: Optional[str]) -> tuple[str, ZoneInfo]:
@@ -44,49 +69,144 @@ def _today_local(tzinfo: ZoneInfo) -> date:
     return datetime.now(tzinfo).date()
 
 
-async def _execute_refresh(user_id: str, day_local: date) -> None:
-    try:
-        pool = await get_pool()
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(
-                    "select marts.refresh_daily_features_user(%s, %s::date)",
-                    (user_id, day_local),
-                )
-    except Exception as exc:  # pragma: no cover - diagnostic logging
+async def _enqueue_backlog(entry: Dict[str, Any]) -> None:
+    async with _backlog_lock:
+        _backlog.append(entry)
         logger.warning(
-            "[MART] refresh failed user=%s day=%s error=%s",
-            user_id,
-            day_local,
-            exc,
+            "[BATCH] buffered payload size=%d backlog_len=%d",
+            len(entry.get("samples", [])),
+            len(_backlog),
         )
 
 
-async def _schedule_refresh(user_id: str, day_local: date, tz_name: str) -> bool:
-    if REFRESH_DISABLED:
-        logger.info(
-            "[MART] refresh disabled; skipping user=%s day=%s tz=%s",
-            user_id,
-            day_local,
-            tz_name,
-        )
-        return False
-    if not user_id:
-        return False
-    loop = asyncio.get_running_loop()
-    async with _refresh_lock:
-        last = _refresh_registry.get(user_id)
-        now = loop.time()
-        if last and now - last < REFRESH_DEBOUNCE_SECONDS:
-            return False
-        _refresh_registry[user_id] = now
+async def _drain_backlog(pool) -> None:
+    if _backlog_drain_lock.locked():
+        return
 
-    async def _runner() -> None:
-        await _execute_refresh(user_id, day_local)
+    async with _backlog_drain_lock:
+        while True:
+            async with _backlog_lock:
+                if not _backlog:
+                    return
+                entry = _backlog.popleft()
 
-    _refresh_task_factory(_runner())
-    logger.info("[MART] scheduled refresh user=%s day=%s tz=%s", user_id, day_local, tz_name)
-    return True
+            samples_data = entry.get("samples", [])
+            dev_uid = entry.get("dev_uid")
+            refresh_user = entry.get("refresh_user")
+            tz_name = entry.get("tz") or DEFAULT_TIMEZONE
+
+            models: List[SampleIn] = []
+            for payload in samples_data:
+                try:
+                    models.append(SampleIn(**payload))
+                except Exception as exc:
+                    logger.warning("[BATCH] dropping buffered sample: %s", exc)
+
+            if not models:
+                continue
+
+            prepared = [(sample, idx) for idx, sample in enumerate(models)]
+            try:
+                inserted, skipped, _ = await safe_insert_batch(pool, prepared, dev_uid)
+            except BatchInsertError as exc:
+                logger.warning("[BATCH] backlog drain halted: %s", exc.reason)
+                async with _backlog_lock:
+                    _backlog.appendleft(entry)
+                break
+
+            if inserted > 0 and refresh_user and not REFRESH_DISABLED:
+                tz_resolved, tzinfo = _resolve_timezone(tz_name)
+                day_local = _today_local(tzinfo)
+                await mart_refresh(refresh_user, day_local)
+                logger.info(
+                    "[BATCH] drained backlog for user=%s tz=%s inserted=%d skipped=%d",
+                    refresh_user,
+                    tz_resolved,
+                    inserted,
+                    skipped,
+                )
+
+
+def _start_backlog_drain(pool) -> None:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:  # pragma: no cover - no running loop
+        return
+    _backlog_task_factory(_drain_backlog(pool))
+
+
+async def safe_insert_batch(
+    pool,
+    rows: List[Tuple[SampleIn, int]],
+    dev_uid: Optional[str],
+) -> Tuple[int, int, List[Dict[str, Any]]]:
+    attempt = 0
+    delay = 0.5
+    last_exc: Optional[BaseException] = None
+    while attempt < 3:
+        try:
+            return await _insert_batch_once(pool, rows, dev_uid)
+        except PoolTimeout as exc:
+            raise BatchInsertError("db_timeout", exc)
+        except OperationalError as exc:
+            last_exc = exc
+            attempt += 1
+            if attempt >= 3:
+                logger.error("[BATCH] insert failed after retries: %s", exc)
+                raise BatchInsertError("db_unavailable", exc)
+            logger.warning("[BATCH] retrying insert... attempt=%d error=%s", attempt, exc)
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 5.0)
+
+    raise BatchInsertError("db_unavailable", last_exc)
+
+
+async def _insert_batch_once(
+    pool,
+    rows: List[Tuple[SampleIn, int]],
+    dev_uid: Optional[str],
+) -> Tuple[int, int, List[Dict[str, Any]]]:
+    inserted = 0
+    skipped = 0
+    errors: List[Dict[str, Any]] = []
+
+    async with pool.connection() as conn:
+        async with conn.cursor() as cur:
+            for sample, original_index in rows:
+                values = (
+                    dev_uid or sample.user_id,
+                    sample.device_os,
+                    sample.source,
+                    sample.type,
+                    sample.start_time,
+                    sample.end_time,
+                    sample.value,
+                    sample.unit,
+                    sample.value_text,
+                )
+                try:
+                    await cur.execute(sql, values, prepare=False)
+                    rowcount = getattr(cur, "rowcount", None)
+                    if rowcount is None:
+                        inserted += 1
+                    else:
+                        inserted += int(rowcount)
+                except pg_errors.UniqueViolation:
+                    skipped += 1
+                except Exception as exc:
+                    skipped += 1
+                    if len(errors) < 10:
+                        errors.append(
+                            {
+                                "index": original_index,
+                                "type": sample.type,
+                                "reason": f"db_error: {type(exc).__name__}",
+                                "message": str(exc)[:200],
+                            }
+                        )
+            await conn.commit()
+
+    return inserted, skipped, errors
 
 
 # ---------- Models ----------
@@ -175,7 +295,7 @@ async def samples_batch(
     # Normalize payload to list
     items = payload.samples if isinstance(payload, SamplesWrapper) else (payload or [])
     if not items:
-        return {"ok": True, "received": 0, "inserted": 0, "skipped": 0}
+        return {"ok": True, "received": 0, "inserted": 0, "skipped": 0, "db": True, "errors": [], "error": None}
 
     batch_start_iso: str | None = None
     batch_end_iso: str | None = None
@@ -208,92 +328,126 @@ async def samples_batch(
     x_uid = request.headers.get("X-Dev-UserId", "").strip() or None
     dev_uid = x_uid
 
-    pool = await get_pool()
-    inserted = 0
-    skipped = 0
-    errors: list[dict] = []
-
     tz_name, tzinfo = _resolve_timezone(tz)
+    received = len(items)
+    validation_errors: List[Dict[str, Any]] = []
+    validation_skipped = 0
+    valid_rows: List[Tuple[SampleIn, int]] = []
+
+    for idx, sample in enumerate(items):
+        ok, reason = _validate_sample(sample)
+        if not ok:
+            validation_skipped += 1
+            if len(validation_errors) < 10:
+                validation_errors.append(
+                    {
+                        "index": idx,
+                        "type": sample.type,
+                        "reason": reason,
+                        "start_time": sample.start_time.isoformat(),
+                    }
+                )
+            continue
+        valid_rows.append((sample, idx))
+
+    refresh_user = None
+    if dev_uid:
+        refresh_user = dev_uid
+    elif batch_user_id and batch_user_id not in {"<mixed>", "<unknown>"}:
+        refresh_user = batch_user_id
+
+    buffer_entry = {
+        "samples": [_sample_to_dict(sample) for sample, _ in valid_rows],
+        "dev_uid": dev_uid,
+        "refresh_user": refresh_user,
+        "tz": tz_name,
+    }
+
+    inserted = 0
+    db_skipped = 0
+    db_errors: List[Dict[str, Any]] = []
+    db_healthy = True
 
     try:
-        async with pool.connection() as conn:
-            async with conn.cursor() as cur:
-                for s in items:
-                    # validate before touching the DB
-                    ok, reason = _validate_sample(s)
-                    if not ok:
-                        skipped += 1
-                        if len(errors) < 10:
-                            errors.append({
-                                "index": skipped + inserted,
-                                "type": s.type,
-                                "reason": reason,
-                                "start_time": s.start_time.isoformat(),
-                            })
-                        continue
-                    # prepare values tuple
-                    v = (
-                        dev_uid or s.user_id,
-                        s.device_os,
-                        s.source,
-                        s.type,
-                        s.start_time,
-                        s.end_time,
-                        s.value,
-                        s.unit,
-                        s.value_text,
-                    )
-                    try:
-                        await cur.execute(sql, v, prepare=False)
-                        inserted += 1
-                    except pg_errors.UniqueViolation:
-                        # on-conflict do nothing should already prevent this, but be safe
-                        continue
-                    except Exception as e:  # capture and keep inserting
-                        skipped += 1
-                        if len(errors) < 10:
-                            errors.append({
-                                "index": skipped + inserted,
-                                "type": s.type,
-                                "reason": f"db_error: {type(e).__name__}",
-                                "message": str(e)[:200],
-                            })
-                await conn.commit()
-        effective_user = dev_uid or batch_user_id or "<unknown>"
-        logger.info(
-            "/samples/batch committed user=%s received=%d inserted=%d window=[%s..%s]",
-            effective_user,
-            len(items),
-            inserted,
-            batch_start_iso or "?",
-            batch_end_iso or "?",
-        )
-        refresh_user = None
-        if dev_uid:
-            refresh_user = dev_uid
-        elif batch_user_id and batch_user_id not in {"<mixed>", "<unknown>"}:
-            refresh_user = batch_user_id
-
-        if inserted > 0 and refresh_user:
-            day_local = _today_local(tzinfo)
-            await _schedule_refresh(refresh_user, day_local, tz_name)
-    except Exception as e:
-        # Return structured response instead of 500 on unexpected failures
-        logger.exception("/samples/batch fatal error: %s", e)
+        pool = await get_pool()
+    except PoolTimeout as exc:
+        logger.error("/samples/batch pool acquisition failed: %s", exc)
+        if valid_rows:
+            await _enqueue_backlog(buffer_entry)
+        errors = list(validation_errors)
+        if not errors:
+            errors = [{"reason": "db_timeout"}]
         return {
             "ok": False,
-            "received": len(items),
-            "inserted": inserted,
-            "skipped": skipped if (inserted + skipped) else len(items),
-            "errors": errors + [{
-                "index": inserted + skipped,
-                "type": "<fatal>",
-                "reason": "server_error",
-                "message": str(e)[:200],
-            }],
+            "received": received,
+            "inserted": 0,
+            "skipped": validation_skipped + len(valid_rows),
+            "db": False,
+            "errors": errors,
+            "error": "db_timeout",
+        }
+    except Exception as exc:
+        logger.exception("/samples/batch unexpected pool error: %s", exc)
+        errors = list(validation_errors)
+        if not errors:
+            errors = [{"reason": "server_error", "message": str(exc)[:200]}]
+        return {
+            "ok": False,
+            "received": received,
+            "inserted": 0,
+            "skipped": received,
+            "db": False,
+            "errors": errors,
+            "error": "server_error",
         }
 
-    resp = {"ok": True, "received": len(items), "inserted": inserted, "skipped": skipped}
-    if errors:
-        resp["errors"] = errors  # include a small sample of what was skipped
-    return resp
+    if valid_rows:
+        try:
+            inserted, db_skipped, db_errors = await safe_insert_batch(pool, valid_rows, dev_uid)
+        except BatchInsertError as exc:
+            db_healthy = False
+            if valid_rows:
+                await _enqueue_backlog(buffer_entry)
+            combined_errors = validation_errors + (db_errors or [])
+            if not combined_errors:
+                combined_errors = [{"reason": exc.reason}]
+            return {
+                "ok": False,
+                "received": received,
+                "inserted": 0,
+                "skipped": validation_skipped + len(valid_rows),
+                "db": False,
+                "errors": combined_errors,
+                "error": exc.reason,
+            }
+
+    total_skipped = validation_skipped + db_skipped
+    combined_errors = validation_errors + db_errors
+
+    effective_user = dev_uid or batch_user_id or "<unknown>"
+    logger.info(
+        "/samples/batch committed user=%s received=%d inserted=%d skipped=%d window=[%s..%s]",
+        effective_user,
+        received,
+        inserted,
+        total_skipped,
+        batch_start_iso or "?",
+        batch_end_iso or "?",
+    )
+
+    if db_healthy:
+        if valid_rows and inserted > 0 and refresh_user and not REFRESH_DISABLED:
+            day_local = _today_local(tzinfo)
+            await mart_refresh(refresh_user, day_local)
+        if valid_rows or _backlog:
+            _start_backlog_drain(pool)
+
+    return {
+        "ok": db_healthy,
+        "received": received,
+        "inserted": inserted,
+        "skipped": total_skipped,
+        "db": db_healthy,
+        "errors": combined_errors,
+        "error": None,
+    }


### PR DESCRIPTION
## Summary
- expand the async postgres pool with watchdog refresh/metrics logging and sturdier connection retries
- harden /v1/samples/batch by validating upfront, buffering payloads, retrying inserts with backoff, and adjusting responses + mart refresh scheduling
- refresh feature caching/fallback with a TTL-backed cache, smarter snapshot recovery, and new db health endpoints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690a3dd09aac832a9fc87dd15f7064a9