### PR TITLE
Fix feature cache serialization for Decimal payloads

### DIFF
--- a/app/cache.py
+++ b/app/cache.py
@@ -15,6 +15,9 @@ import time
 from collections import OrderedDict
 from typing import Any, Dict, Optional
 
+from decimal import Decimal
+from uuid import UUID
+
 from .db import settings
 
 try:  # pragma: no cover - exercised in environments with Redis available
@@ -65,6 +68,11 @@ _redis_attempted = False
 
 
 def _json_default(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        # Preserve numeric semantics while ensuring JSON compatibility
+        return float(value)
+    if isinstance(value, UUID):
+        return str(value)
     if hasattr(value, "isoformat"):
         try:
             return value.isoformat()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,24 @@
+from decimal import Decimal
+
+import pytest
+
+from app.cache import FeatureCache
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def test_feature_cache_serializes_decimal_values():
+    cache = FeatureCache()
+    user_id = "test-user"
+    payload = {"value": Decimal("1.25"), "nested": {"score": Decimal("2.5")}}
+
+    await cache.set(user_id, payload)
+
+    restored = await cache.get(user_id)
+    assert restored == {"value": 1.25, "nested": {"score": 2.5}}


### PR DESCRIPTION
## Summary
- convert Decimal and UUID values when serializing feature cache payloads
- add a regression test confirming the feature cache can round-trip Decimal values

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_690a4f5c2628832aa30cb3435c6684b0