### PR TITLE
Add sticky health probe and debounce mart refresh scheduling

### DIFF
--- a/tests/api/test_features_today.py
+++ b/tests/api/test_features_today.py
@@ -84,6 +84,8 @@ def anyio_backend():
 @pytest.mark.anyio
 async def test_refresh_scheduled_on_ingest(monkeypatch, client: AsyncClient):
     ingest._refresh_registry.clear()
+    ingest._recent_refresh_requests.clear()
+    monkeypatch.setattr(summary, "_REFRESH_DELAY_RANGE", (0.0, 0.0))
 
     fake_pool = _FakePool()
 
@@ -130,6 +132,7 @@ async def test_refresh_scheduled_on_ingest(monkeypatch, client: AsyncClient):
     body = resp.json()
     assert body["ok"] is True
     await asyncio.sleep(0)
+    await asyncio.sleep(0.01)
     assert scheduled, "refresh task should be scheduled"
     scheduled_user, scheduled_day = scheduled[0]
     assert scheduled_user == user_id


### PR DESCRIPTION
## Summary
- add a sticky database health probe with a short timeout, grace window, and diagnostic logging
- only enqueue mart refreshes when inserts occur, add a per-user debounce, and defer execution via a delayed background task
- prevent overlapping refresh runs and update the batch ingest test harness for the new scheduling behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690ac30aac34832aa766dbc3f33d2d50