### PR TITLE
Stabilize Supabase connectivity and refresh handling

### DIFF
--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -13,9 +13,9 @@ from psycopg_pool.errors import PoolTimeout
 from fastapi import APIRouter, Body, Depends, Request, Header, HTTPException, status, Query
 from pydantic import BaseModel
 
-from ..db import get_pool, settings  # settings.DEV_BEARER, async pg pool
+from ..db import get_pool, settings, get_db_health_cached, register_health_listener
 from . import summary as _summary_module
-from .summary import mart_refresh
+from .summary import enqueue_refresh_today
 
 from zoneinfo import ZoneInfo
 from os import getenv
@@ -141,30 +141,46 @@ def _start_backlog_drain(pool) -> None:
     _backlog_task_factory(_drain_backlog(pool))
 
 
+async def _on_db_health_change(status: bool) -> None:
+    if not status:
+        return
+    try:
+        pool = await get_pool()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("[BATCH] backlog drain skipped on health flip: %s", exc)
+        return
+    _start_backlog_drain(pool)
+
+
+register_health_listener(_on_db_health_change)
+
+
 async def safe_insert_batch(
     pool,
     rows: List[Tuple[SampleIn, int]],
     dev_uid: Optional[str],
 ) -> Tuple[int, int, List[Dict[str, Any]]]:
+    retry_delays = [0.5, 1.0]
     attempt = 0
-    delay = 0.5
-    last_exc: Optional[BaseException] = None
-    while attempt < 3:
+    while True:
         try:
             return await _insert_batch_once(pool, rows, dev_uid)
-        except PoolTimeout as exc:
-            raise BatchInsertError("db_timeout", exc)
-        except OperationalError as exc:
-            last_exc = exc
-            attempt += 1
-            if attempt >= 3:
+        except (PoolTimeout, OperationalError) as exc:
+            if attempt >= len(retry_delays):
                 logger.error("[BATCH] insert failed after retries: %s", exc)
-                raise BatchInsertError("db_unavailable", exc)
-            logger.warning("[BATCH] retrying insert... attempt=%d error=%s", attempt, exc)
+                raise BatchInsertError("db_timeout", exc)
+            delay = retry_delays[attempt]
+            attempt += 1
+            logger.warning(
+                "[BATCH] retrying insert attempt=%d delay=%.1fs error=%s",
+                attempt + 1,
+                delay,
+                exc,
+            )
             await asyncio.sleep(delay)
-            delay = min(delay * 2, 5.0)
-
-    raise BatchInsertError("db_unavailable", last_exc)
+            continue
+        except Exception as exc:
+            raise BatchInsertError("db_timeout", exc)
 
 
 async def _insert_batch_once(
@@ -385,7 +401,25 @@ async def samples_batch(
     inserted = 0
     db_skipped = 0
     db_errors: List[Dict[str, Any]] = []
-    db_healthy = True
+
+    db_status, sticky_age_ms = get_db_health_cached()
+    if not db_status:
+        if valid_rows:
+            await _enqueue_backlog(buffer_entry)
+        errors = list(validation_errors)
+        errors.append({"reason": "db_unavailable"})
+        skipped_total = received
+        _log_batch_summary(effective_user or "<unknown>", received, 0, skipped_total, False)
+        return {
+            "ok": False,
+            "received": received,
+            "inserted": 0,
+            "skipped": skipped_total,
+            "db": False,
+            "errors": errors,
+            "error": "db_unavailable",
+            "db_sticky_age": sticky_age_ms,
+        }
 
     try:
         pool = await get_pool()
@@ -394,14 +428,14 @@ async def samples_batch(
         if valid_rows:
             await _enqueue_backlog(buffer_entry)
         errors = list(validation_errors)
-        if not errors:
-            errors = [{"reason": "db_timeout"}]
-        _log_batch_summary(effective_user or "<unknown>", received, 0, validation_skipped + len(valid_rows), False)
+        errors.append({"reason": "db_timeout"})
+        skipped_total = validation_skipped + len(valid_rows)
+        _log_batch_summary(effective_user or "<unknown>", received, 0, skipped_total, False)
         return {
             "ok": False,
             "received": received,
             "inserted": 0,
-            "skipped": validation_skipped + len(valid_rows),
+            "skipped": skipped_total,
             "db": False,
             "errors": errors,
             "error": "db_timeout",
@@ -409,8 +443,7 @@ async def samples_batch(
     except Exception as exc:
         logger.exception("/samples/batch unexpected pool error: %s", exc)
         errors = list(validation_errors)
-        if not errors:
-            errors = [{"reason": "server_error", "message": str(exc)[:200]}]
+        errors.append({"reason": "server_error", "message": str(exc)[:200]})
         _log_batch_summary(effective_user or "<unknown>", received, 0, received, False)
         return {
             "ok": False,
@@ -422,22 +455,25 @@ async def samples_batch(
             "error": "server_error",
         }
 
+    if _backlog:
+        _start_backlog_drain(pool)
+
     if valid_rows:
         try:
             inserted, db_skipped, db_errors = await safe_insert_batch(pool, valid_rows, dev_uid)
         except BatchInsertError as exc:
-            db_healthy = False
             if valid_rows:
                 await _enqueue_backlog(buffer_entry)
             combined_errors = validation_errors + (db_errors or [])
             if not combined_errors:
                 combined_errors = [{"reason": exc.reason}]
-            _log_batch_summary(effective_user or "<unknown>", received, 0, validation_skipped + len(valid_rows), False)
+            skipped_total = validation_skipped + len(valid_rows)
+            _log_batch_summary(effective_user or "<unknown>", received, 0, skipped_total, False)
             return {
                 "ok": False,
                 "received": received,
                 "inserted": 0,
-                "skipped": validation_skipped + len(valid_rows),
+                "skipped": skipped_total,
                 "db": False,
                 "errors": combined_errors,
                 "error": exc.reason,
@@ -457,21 +493,21 @@ async def samples_batch(
         batch_end_iso or "?",
     )
 
-    if db_healthy:
-        if valid_rows and inserted > 0 and refresh_user and not REFRESH_DISABLED:
-            day_local = _today_local(tzinfo)
-            await _maybe_schedule_refresh(refresh_user, day_local, inserted)
-        if valid_rows or _backlog:
-            _start_backlog_drain(pool)
+    if valid_rows and inserted > 0 and refresh_user and not REFRESH_DISABLED:
+        day_local = _today_local(tzinfo)
+        await _maybe_schedule_refresh(refresh_user, day_local, inserted)
 
-    _log_batch_summary(effective_user, received, inserted, total_skipped, db_healthy)
+    if valid_rows and inserted > 0:
+        _start_backlog_drain(pool)
+
+    _log_batch_summary(effective_user, received, inserted, total_skipped, True)
 
     return {
-        "ok": db_healthy,
+        "ok": True,
         "received": received,
         "inserted": inserted,
         "skipped": total_skipped,
-        "db": db_healthy,
+        "db": True,
         "errors": combined_errors,
         "error": None,
     }
@@ -489,7 +525,7 @@ async def _maybe_schedule_refresh(user_id: str, day_local: date, inserted: int) 
                 _INGEST_REFRESH_DEBOUNCE_SECONDS,
             )
             return False
-    scheduled = await mart_refresh(user_id, day_local)
+    scheduled = await enqueue_refresh_today(user_id, day_local)
     if scheduled:
         async with _recent_refresh_lock:
             _recent_refresh_requests[user_id] = loop.time()

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,12 +1,12 @@
 # Operations Runbook
 
 ## Supabase configuration
-- Set **POOL_MODE=transaction** for the project's pgBouncer configuration when using async clients.
+- Point application traffic at the **pgBouncer endpoint on port 6543** and set **POOL_MODE=transaction** when using async clients.
 - Keep the project in the "Running" state; paused projects will close existing connections and cause client pool churn.
 - Tune pgBouncer `idle_timeout` to be at least 60 seconds so short gaps in traffic do not recycle connections immediately.
 
 ## Render environment
-- `DATABASE_URL` should target the pgBouncer endpoint on port **6543** and include `sslmode=require` in the query string.
+- `DATABASE_URL` must target the pgBouncer endpoint on port **6543** and include `sslmode=require` in the query string.
 - Restarting the service will automatically reopen the shared async connection pool during FastAPI startup.
 
 ## Connectivity checks


### PR DESCRIPTION
## Summary
- add sticky database health monitoring with pooled pgBouncer settings and expose metrics for /health and /v1/diag/db
- guard ingest batch writes when the database is unavailable, retry inserts conservatively, and queue refresh jobs once inserts succeed
- run an in-process refresh worker that debounces jobs, waits for a healthy database, and refreshes daily features with detailed diagnostics

## Testing
- pytest tests/api/test_features_today.py

------
https://chatgpt.com/codex/tasks/task_e_690af0f4ec20832ab3866ea53f355d6e