### PR TITLE
Handle DB pool timeouts for features endpoint with cache fallback

### DIFF
--- a/app/routers/summary.py
+++ b/app/routers/summary.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 import random
+from contextlib import asynccontextmanager
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from time import perf_counter
@@ -13,6 +14,7 @@ from fastapi import APIRouter, Depends, Request
 from os import getenv
 from psycopg import errors as pg_errors
 from psycopg.rows import dict_row
+from psycopg_pool import PoolTimeout
 from app.cache import get_last_good, set_last_good
 from app.db import get_db, get_pool, get_pool_metrics
 from app.utils.auth import require_admin
@@ -29,6 +31,29 @@ STATEMENT_TIMEOUT_MS = 60000
 
 MART_REFRESH_DEBOUNCE_SECONDS = 180.0
 _REFRESH_DELAY_RANGE = (1.5, 2.0)
+
+
+@asynccontextmanager
+async def _acquire_features_conn():
+    """Acquire a database connection for the features endpoint."""
+
+    pool = await get_pool()
+    ctx = pool.connection()
+    try:
+        conn = await ctx.__aenter__()
+    except Exception:
+        raise
+
+    try:
+        await conn.execute(f"set statement_timeout = {STATEMENT_TIMEOUT_MS}")
+    except Exception as exc:
+        await ctx.__aexit__(type(exc), exc, exc.__traceback__)
+        raise
+
+    try:
+        yield conn
+    finally:
+        await ctx.__aexit__(None, None, None)
 
 
 _refresh_registry: Dict[str, float] = {}
@@ -123,6 +148,24 @@ _MART_COLUMNS = [
 _MART_SELECT = ", ".join(_MART_COLUMNS)
 
 
+def _init_diag_info(user_id: Optional[str], tz_name: str) -> Dict[str, Any]:
+    return {
+        "branch": "scoped" if user_id else "anonymous",
+        "statement_timeout_ms": STATEMENT_TIMEOUT_MS,
+        "requested_user_id": str(user_id) if user_id else None,
+        "user_id": str(user_id) if user_id else None,
+        "day": None,
+        "day_used": None,
+        "updated_at": None,
+        "source": "empty",
+        "mart_row": False,
+        "freshened": False,
+        "max_day": None,
+        "total_rows": None,
+        "tz": tz_name,
+    }
+
+
 def _iso_dt(value: Optional[datetime]) -> Optional[str]:
     if value is None:
         return None
@@ -135,6 +178,17 @@ def _iso_date(value: Optional[date]) -> Optional[str]:
     if value is None:
         return None
     return value.isoformat()
+
+
+def _coerce_day(value: Any) -> Optional[date]:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
 
 
 def _normalize_timezone(tz_name: Optional[str]) -> Tuple[str, ZoneInfo]:
@@ -654,21 +708,7 @@ async def _collect_features(
     tz_name: str,
     tzinfo: ZoneInfo,
 ) -> Tuple[Dict[str, Any], Dict[str, Any], Optional[str]]:
-    diag_info: Dict[str, Any] = {
-        "branch": "scoped" if user_id else "anonymous",
-        "statement_timeout_ms": STATEMENT_TIMEOUT_MS,
-        "requested_user_id": str(user_id) if user_id else None,
-        "user_id": str(user_id) if user_id else None,
-        "day": None,
-        "day_used": None,
-        "updated_at": None,
-        "source": "empty",
-        "mart_row": False,
-        "freshened": False,
-        "max_day": None,
-        "total_rows": None,
-        "tz": tz_name,
-    }
+    diag_info: Dict[str, Any] = _init_diag_info(user_id, tz_name)
 
     response_payload: Dict[str, Any] = {}
     error_text: Optional[str] = None
@@ -817,6 +857,51 @@ async def _collect_features(
     return response_payload, diag_info, error_text
 
 
+async def _fallback_from_cache(
+    diag_seed: Dict[str, Any],
+    user_id: Optional[str],
+    tzinfo: ZoneInfo,
+    *,
+    reason: Optional[str] = None,
+) -> Tuple[Dict[str, Any], Dict[str, Any], Optional[str]]:
+    diag_info = dict(diag_seed)
+    base_day = _coerce_day(diag_info.get("day"))
+    if not base_day:
+        base_day = datetime.now(tzinfo).date()
+    diag_info["day"] = base_day
+    diag_info.setdefault("day_used", base_day)
+    diag_info.setdefault("source", "cache")
+    diag_info["cache_fallback"] = True
+    if reason:
+        diag_info["error"] = reason
+
+    cached_payload = await get_last_good(user_id)
+    if cached_payload:
+        payload = dict(cached_payload)
+        diag_info["mart_row"] = bool(payload)
+        diag_info["source"] = payload.get("source") or diag_info.get("source") or "cache"
+        diag_info["updated_at"] = payload.get("updated_at")
+        cached_day = _coerce_day(payload.get("day"))
+        if cached_day:
+            diag_info["day_used"] = cached_day
+        payload.setdefault("source", diag_info["source"])
+        logger.warning(
+            "[features_today] serving cached payload user=%s source=%s",
+            user_id,
+            diag_info.get("source"),
+        )
+        return payload, diag_info, None
+
+    payload = {"source": diag_info.get("source") or "cache"}
+    fallback_error = reason or "database temporarily unavailable"
+    logger.error(
+        "[features_today] cache unavailable user=%s reason=%s",
+        user_id,
+        fallback_error,
+    )
+    return payload, diag_info, fallback_error
+
+
 def _format_diag_payload(diag_info: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "branch": diag_info.get("branch"),
@@ -832,6 +917,9 @@ def _format_diag_payload(diag_info: Dict[str, Any]) -> Dict[str, Any]:
         "max_day": _iso_date(diag_info.get("max_day")),
         "total_rows": diag_info.get("total_rows"),
         "tz": diag_info.get("tz"),
+        "cache_fallback": bool(diag_info.get("cache_fallback")),
+        "pool_timeout": bool(diag_info.get("pool_timeout")),
+        "error": diag_info.get("error"),
     }
 
 router = APIRouter(prefix="/v1")
@@ -840,7 +928,7 @@ router = APIRouter(prefix="/v1")
 # /v1/features/today (full)
 # -----------------------------
 @router.get("/features/today")
-async def features_today(request: Request, diag: int = 0, conn = Depends(get_db)):
+async def features_today(request: Request, diag: int = 0):
     """Return the daily features snapshot for the caller, honoring timezone overrides."""
 
     default_media_base = "https://cdn.jsdelivr.net/gh/GaiaEyesHQ/gaiaeyes-media@main"
@@ -853,7 +941,38 @@ async def features_today(request: Request, diag: int = 0, conn = Depends(get_db)
     user_id = getattr(request.state, "user_id", None)
     if diag:
         logger.debug("[features_today] diagnostics requested tz=%s user=%s", tz_name, user_id)
-    response_payload, diag_info, error_text = await _collect_features(conn, user_id, tz_name, tzinfo)
+    diag_seed = _init_diag_info(user_id, tz_name)
+    diag_seed["day"] = datetime.now(tzinfo).date()
+    diag_seed["day_used"] = diag_seed["day"]
+
+    try:
+        async with _acquire_features_conn() as conn:
+            response_payload, diag_info, error_text = await _collect_features(conn, user_id, tz_name, tzinfo)
+    except PoolTimeout as exc:
+        logger.warning(
+            "[features_today] pool timeout tz=%s user=%s: %s", tz_name, user_id, exc
+        )
+        diag_seed["pool_timeout"] = True
+        response_payload, diag_info, error_text = await _fallback_from_cache(
+            diag_seed,
+            user_id,
+            tzinfo,
+            reason="database temporarily unavailable",
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging
+        reason = str(exc) or exc.__class__.__name__
+        logger.exception(
+            "[features_today] connection acquisition failed tz=%s user=%s: %s",
+            tz_name,
+            user_id,
+            reason,
+        )
+        response_payload, diag_info, error_text = await _fallback_from_cache(
+            diag_seed,
+            user_id,
+            tzinfo,
+            reason=reason,
+        )
 
     if error_text:
         response: Dict[str, Any] = {"ok": False, "data": None, "error": error_text}
@@ -900,21 +1019,7 @@ async def diag_features(
     if effective_user:
         features_payload, diag_info, error_text = await _collect_features(conn, effective_user, tz_name, tzinfo)
     else:
-        diag_info = {
-            "branch": "anonymous",
-            "statement_timeout_ms": STATEMENT_TIMEOUT_MS,
-            "requested_user_id": None,
-            "user_id": None,
-            "day": None,
-            "day_used": None,
-            "updated_at": None,
-            "source": "empty",
-            "mart_row": False,
-            "freshened": False,
-            "max_day": None,
-            "total_rows": None,
-            "tz": tz_name,
-        }
+        diag_info = _init_diag_info(None, tz_name)
 
     mart_rows: List[Dict[str, Any]] = []
     samples_window: Dict[str, Any] = {}

--- a/docs/CODEX_CHANGELOG.md
+++ b/docs/CODEX_CHANGELOG.md
@@ -1,0 +1,9 @@
+# Codex Change Log
+
+Document noteworthy backend/front-end changes implemented via Codex tasks. Keep the newest entries at the top.
+
+## 2024-04-05 — Features endpoint cache hardening
+
+- Guarded `/v1/features/today` against pgBouncer pool exhaustion by attempting a manual connection acquisition and falling back to the last-good cache snapshot when the pool is saturated.
+- Extended diagnostics with `cache_fallback`, `pool_timeout`, and `error` markers so client teams can detect when cached data was served.
+- Added automated tests covering the new cache fallback branch and updated docs describing the behavior.

--- a/docs/DIAG_FEATURES.md
+++ b/docs/DIAG_FEATURES.md
@@ -12,6 +12,8 @@ curl -s -H "Authorization: Bearer <token>" \
 The response includes:
 
 - `features`: metadata about the most recent `/v1/features/today` query, including the requested user id, which branch (scoped vs. fallback) was used, and the latest `day`/`updated_at` timestamps.
+  - `cache_fallback` and `pool_timeout` highlight when the handler served cached data because the database pool was saturated.
+  - `error` carries the most recent connection or query error (if any) that triggered the fallback path.
 - `tables`: row counts and latest timestamps for the tables that feed the feature rollup.
   - `marts.daily_features` shows the global feature mart freshness (`max_day` and `max_updated_at`).
   - `marts.schumann_daily` reports the latest Schumann resonance day available.
@@ -34,7 +36,10 @@ Example fragment:
     "max_day": "2024-05-06",
     "total_rows": 128,
     "has_row": true,
-    "statement_timeout_ms": 60000
+    "statement_timeout_ms": 60000,
+    "cache_fallback": false,
+    "pool_timeout": false,
+    "error": null
   },
   "tables": {
     "marts.daily_features": {

--- a/docs/FEATURES_ROUTE.md
+++ b/docs/FEATURES_ROUTE.md
@@ -19,7 +19,7 @@ The `/v1/features/today` endpoint returns a consolidated “daily features” sn
     "branch": "scoped" | "anonymous",
     "day": "YYYY-MM-DD" | null,
     "day_used": "YYYY-MM-DD" | null,
-    "source": "today" | "freshened" | "yesterday" | "empty",
+    "source": "today" | "freshened" | "yesterday" | "empty" | "cache",
     "mart_row": true|false,
     "freshened": true|false,
     "statement_timeout_ms": int,
@@ -28,7 +28,10 @@ The `/v1/features/today` endpoint returns a consolidated “daily features” sn
     "updated_at": ISO8601|null,
     "max_day": "YYYY-MM-DD" | null,
     "total_rows": int|null,
-    "tz": string
+    "tz": string,
+    "cache_fallback": true|false,
+    "pool_timeout": true|false,
+    "error": string|null
   }
 }
 ```
@@ -40,6 +43,7 @@ The `/v1/features/today` endpoint returns a consolidated “daily features” sn
 1. **Today’s mart row** – if `marts.daily_features` already contains `(user_id, today_local)` the handler hydrates it with live sleep and space weather context.
 2. **Freshen** – if today’s row is missing, the handler performs a short “freshen” by combining `gaia.daily_summary`, raw sleep samples, and space-weather feeds. The response is annotated with `source:"freshened"` and `freshened:true`.
 3. **Yesterday fallback** – when neither of the above produce data, the handler loads yesterday’s mart row and marks `source:"yesterday"`.
-4. **Empty** – if no data exists, the response is `{}` with `source:"empty"`.
+4. **Cache fallback** – when the service cannot obtain a database connection (for example when pgBouncer is saturated), the handler serves the last-good payload from the in-memory/Redis cache, marks `cache_fallback:true`, and sets `pool_timeout:true`. Clients continue to receive populated tiles even while the database is briefly unavailable.
+5. **Empty** – if no data or cache entry exists, the response is `{}` with `source:"empty"` (and `ok:false` when a hard error occurs).
 
 Because diagnostics are always returned, client teams can inspect `diagnostics.day_used`, `source`, and `mart_row` to understand which branch served the payload.

--- a/docs/ios repo-UI docs-frontend/StatsCacheFallback.md
+++ b/docs/ios repo-UI docs-frontend/StatsCacheFallback.md
@@ -1,0 +1,16 @@
+# Stats Cards Cache Fallback Notes
+
+The backend now surfaces two new diagnostics on `/v1/features/today` to indicate when cached data was returned instead of a fresh mart snapshot:
+
+- `diagnostics.cache_fallback` — `true` when the handler served the last good payload from Redis / in-memory cache.
+- `diagnostics.pool_timeout` — `true` when the cache fallback was triggered because the database pool was saturated (pgBouncer timeout).
+- `diagnostics.error` — populated with the last connection/query error so the UI can display an actionable banner.
+
+To keep the iOS dashboard stable and avoid the refresh loop that was observed, please queue the following Codex task for the SwiftUI repo:
+
+1. **Surface the new diagnostics.** Extend the feature envelope parsing in `ContentView.swift` so the `FeatureFetchState` tracks `cacheFallback`, `poolTimeout`, and `error` strings alongside the existing `source` metadata. Use the decoded flags to show the existing stale-data toast/badge path instead of hard-refreshing immediately. 【F:ios/GaiaExporter/Views/ContentView.swift†L839-L918】
+2. **Throttle follow-up refreshes.** When `cacheFallback` is `true`, pause automatic retries for ~2 minutes before the next fetch attempt (reuse the existing `featuresRetryWorkItem` guard). Only resume aggressive retries once diagnostics show `cacheFallback == false`. This prevents the UI from hammering the backend while the database pool recovers. 【F:ios/GaiaExporter/Views/ContentView.swift†L981-L1053】
+3. **Display a user-facing banner.** Reuse the offline/stale badge styling to display a short message such as “Showing cached data while the network recovers” when `cacheFallback` is `true`. Include the diagnostics `error` text in the debug panel so testers can confirm the backend reason. 【F:ios/GaiaExporter/Views/ContentView.swift†L972-L974】【F:ios/GaiaExporter/Views/ContentView.swift†L1731-L1751】
+4. **Protect the pull-to-refresh gesture.** Update the pull-to-refresh handler to respect the new cooldown when `cacheFallback` is active so manual refreshes still work but do not queue multiple simultaneous fetches. 【F:ios/GaiaExporter/Views/ContentView.swift†L1015-L1094】
+
+These tweaks ensure the dashboard keeps showing the last-good stats during short outages instead of repeatedly refreshing and freezing the UI.

--- a/tests/api/test_features_today.py
+++ b/tests/api/test_features_today.py
@@ -18,8 +18,9 @@ if str(ROOT) not in sys.path:
 pytestmark = pytest.mark.anyio("asyncio")
 
 from app.main import app
-from app.db import get_db, settings
+from app.db import settings
 from app.routers import ingest, summary
+from psycopg_pool import PoolTimeout
 
 
 @pytest.fixture(autouse=True)
@@ -60,6 +61,9 @@ class _FakeConn:
         return _FakeCursor()
 
     async def commit(self):
+        return None
+
+    async def execute(self, *args, **kwargs):  # noqa: ARG002
         return None
 
 
@@ -141,10 +145,10 @@ async def test_refresh_scheduled_on_ingest(monkeypatch, client: AsyncClient):
 
 @pytest.mark.anyio
 async def test_features_fallback_to_yesterday(monkeypatch, client: AsyncClient):
-    async def _fake_db():
-        yield _FakeConn()
+    def _fake_acquire():
+        return _FakeConnContext()
 
-    app.dependency_overrides[get_db] = _fake_db
+    monkeypatch.setattr(summary, "_acquire_features_conn", _fake_acquire)
 
     today = date(2024, 4, 3)
     yesterday = date(2024, 4, 2)
@@ -192,28 +196,25 @@ async def test_features_fallback_to_yesterday(monkeypatch, client: AsyncClient):
     monkeypatch.setattr(summary, "_fetch_daily_post", _fake_post)
 
     user_id = str(uuid4())
-    try:
-        resp = await client.get(
-            "/v1/features/today",
-            headers={"Authorization": "Bearer test-token", "X-Dev-UserId": user_id},
-            params={"tz": "UTC"},
-        )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["ok"] is True
-        assert data["data"]["day"] == yesterday.isoformat()
-        assert data["diagnostics"]["source"] == "yesterday"
-        assert data["diagnostics"]["day_used"] == yesterday.isoformat()
-    finally:
-        app.dependency_overrides.pop(get_db, None)
+    resp = await client.get(
+        "/v1/features/today",
+        headers={"Authorization": "Bearer test-token", "X-Dev-UserId": user_id},
+        params={"tz": "UTC"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["data"]["day"] == yesterday.isoformat()
+    assert data["diagnostics"]["source"] == "yesterday"
+    assert data["diagnostics"]["day_used"] == yesterday.isoformat()
 
 
 @pytest.mark.anyio
 async def test_features_returns_defaults_when_empty(monkeypatch, client: AsyncClient):
-    async def _fake_db():
-        yield _FakeConn()
+    def _fake_acquire():
+        return _FakeConnContext()
 
-    app.dependency_overrides[get_db] = _fake_db
+    monkeypatch.setattr(summary, "_acquire_features_conn", _fake_acquire)
 
     today = date(2024, 4, 5)
 
@@ -248,33 +249,30 @@ async def test_features_returns_defaults_when_empty(monkeypatch, client: AsyncCl
 
     user_id = str(uuid4())
 
-    try:
-        resp = await client.get(
-            "/v1/features/today",
-            headers={"Authorization": "Bearer test-token", "X-Dev-UserId": user_id},
-            params={"tz": "UTC"},
-        )
-        assert resp.status_code == 200
-        payload = resp.json()
-        assert payload["ok"] is True
-        data = payload["data"]
-        assert data["user_id"] == user_id
-        assert data["day"] == today.isoformat()
-        assert data["steps_total"] == 0
-        assert data["sleep_total_minutes"] == 0
-        assert data["flares_count"] == 0
-        assert data["kp_alert"] is False
-        assert data["source"] in {"snapshot", "empty"}
-    finally:
-        app.dependency_overrides.pop(get_db, None)
+    resp = await client.get(
+        "/v1/features/today",
+        headers={"Authorization": "Bearer test-token", "X-Dev-UserId": user_id},
+        params={"tz": "UTC"},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["ok"] is True
+    data = payload["data"]
+    assert data["user_id"] == user_id
+    assert data["day"] == today.isoformat()
+    assert data["steps_total"] == 0
+    assert data["sleep_total_minutes"] == 0
+    assert data["flares_count"] == 0
+    assert data["kp_alert"] is False
+    assert data["source"] in {"snapshot", "empty"}
 
 
 @pytest.mark.anyio
 async def test_features_error_envelope(monkeypatch, client: AsyncClient):
-    async def _fake_db():
-        yield _FakeConn()
+    def _fake_acquire():
+        return _FakeConnContext()
 
-    app.dependency_overrides[get_db] = _fake_db
+    monkeypatch.setattr(summary, "_acquire_features_conn", _fake_acquire)
 
     async def _fake_collect(conn, user_id, tz_name, tzinfo):  # noqa: ARG001
         return {}, {
@@ -296,28 +294,25 @@ async def test_features_error_envelope(monkeypatch, client: AsyncClient):
     monkeypatch.setattr(summary, "_collect_features", _fake_collect)
 
     user_id = str(uuid4())
-    try:
-        resp = await client.get(
-            "/v1/features/today",
-            headers={"Authorization": "Bearer test-token", "X-Dev-UserId": user_id},
-            params={"tz": "UTC"},
-        )
-        assert resp.status_code == 200
-        payload = resp.json()
-        assert payload["ok"] is False
-        assert payload["data"] is None
-        assert payload["error"] == "boom"
-        assert payload["diagnostics"]["source"] == "empty"
-    finally:
-        app.dependency_overrides.pop(get_db, None)
+    resp = await client.get(
+        "/v1/features/today",
+        headers={"Authorization": "Bearer test-token", "X-Dev-UserId": user_id},
+        params={"tz": "UTC"},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["ok"] is False
+    assert payload["data"] is None
+    assert payload["error"] == "boom"
+    assert payload["diagnostics"]["source"] == "empty"
 
 
 @pytest.mark.anyio
 async def test_features_db_error_envelope(monkeypatch, client: AsyncClient):
-    async def _fake_db():
-        yield _FakeConn()
+    def _fake_acquire():
+        return _FakeConnContext()
 
-    app.dependency_overrides[get_db] = _fake_db
+    monkeypatch.setattr(summary, "_acquire_features_conn", _fake_acquire)
 
     async def _boom_current_day(conn, tz_name):  # noqa: ARG001
         raise RuntimeError("database unavailable")
@@ -325,17 +320,58 @@ async def test_features_db_error_envelope(monkeypatch, client: AsyncClient):
     monkeypatch.setattr(summary, "_current_day_local", _boom_current_day)
 
     user_id = str(uuid4())
-    try:
-        resp = await client.get(
-            "/v1/features/today",
-            headers={"Authorization": "Bearer test-token", "X-Dev-UserId": user_id},
-            params={"tz": "UTC"},
-        )
-        assert resp.status_code == 200
-        payload = resp.json()
-        assert payload["ok"] is False
-        assert payload["data"] is None
-        assert payload["error"] == "database unavailable"
-        assert payload["diagnostics"]["source"] == "empty"
-    finally:
-        app.dependency_overrides.pop(get_db, None)
+    resp = await client.get(
+        "/v1/features/today",
+        headers={"Authorization": "Bearer test-token", "X-Dev-UserId": user_id},
+        params={"tz": "UTC"},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["ok"] is False
+    assert payload["data"] is None
+    assert payload["error"] == "database unavailable"
+    assert payload["diagnostics"]["source"] == "empty"
+
+
+@pytest.mark.anyio
+async def test_features_pool_timeout_uses_cache(monkeypatch, client: AsyncClient):
+    class _FailCtx:
+        async def __aenter__(self):
+            raise PoolTimeout("timeout")
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    def _boom_acquire():
+        return _FailCtx()
+
+    async def _fake_get_last_good(user_id: str):  # noqa: ARG001
+        return {
+            "user_id": user_id,
+            "day": "2024-04-05",
+            "source": "snapshot",
+            "steps_total": 3210,
+        }
+
+    async def _noop_set_last_good(user_id: str, payload):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(summary, "_acquire_features_conn", _boom_acquire)
+    monkeypatch.setattr(summary, "get_last_good", _fake_get_last_good)
+    monkeypatch.setattr(summary, "set_last_good", _noop_set_last_good)
+
+    user_id = str(uuid4())
+
+    resp = await client.get(
+        "/v1/features/today",
+        headers={"Authorization": "Bearer test-token", "X-Dev-UserId": user_id},
+        params={"tz": "UTC"},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["ok"] is True
+    data = payload["data"]
+    assert data["steps_total"] == 3210
+    assert data["day"] == "2024-04-05"
+    assert payload["diagnostics"]["cache_fallback"] is True
+    assert payload["diagnostics"]["pool_timeout"] is True


### PR DESCRIPTION
## Summary
- guard `/v1/features/today` connection acquisition, fall back to the cached snapshot when the pool times out, and expose the new diagnostics
- document the cache fallback flow, add a Codex change log entry, and capture the recommended frontend follow-up
- extend the API tests to cover the new timeout and cache scenarios

## Testing
- pytest tests/api/test_features_today.py -q

------
https://chatgpt.com/codex/tasks/task_e_690bf628b940832a9d785dc8f4346453