### PR TITLE
Automatically derive direct DB fallback when pgBouncer is unavailable

### DIFF
--- a/docs/CODEX_CHANGELOG.md
+++ b/docs/CODEX_CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Document noteworthy backend/front-end changes implemented via Codex tasks. Keep the newest entries at the top.
 
+## 2024-04-12 — Restore automatic direct DB fallback
+
+- Detect pgBouncer usage when the Supabase connection string already points to port 6543
+  and automatically derive a direct Postgres fallback on port 5432 when no explicit
+  `DIRECT_URL` is configured. This prevents connection loops that left the `/v1/features/today`
+  endpoint stuck on cached payloads while pgBouncer was unavailable.
+- Added regression coverage asserting the inferred fallback wiring.
+
 ## 2024-04-11 — Harden database connectivity and symptom fallbacks
 
 - Update the async pool bootstrapper to respect the original `DATABASE_URL` port, only switch to pgBouncer when explicitly

--- a/tests/test_db_conninfo.py
+++ b/tests/test_db_conninfo.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import sys
+from urllib.parse import urlparse
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app import db
+
+
+def _reset_pool_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(db, "_pool_conninfo_primary", None)
+    monkeypatch.setattr(db, "_pool_conninfo_fallback", None)
+    monkeypatch.setattr(db, "_pool_primary_label", "unknown")
+    monkeypatch.setattr(db, "_pool_fallback_label", None)
+    monkeypatch.setattr(db, "_pool_active_label", "unknown")
+
+
+def test_prepare_conninfo_infers_pgbouncer_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reset_pool_state(monkeypatch)
+
+    monkeypatch.setattr(
+        db.settings,
+        "DATABASE_URL",
+        "postgresql://user:pass@db.example.com:6543/postgres?sslmode=require",
+    )
+    monkeypatch.setattr(db.settings, "DIRECT_URL", None)
+
+    db._prepare_conninfo()
+
+    assert db._pool_primary_label == "pgbouncer"
+    assert db._pool_active_label == "pgbouncer"
+    assert db._pool_conninfo_primary.endswith(":6543/postgres?sslmode=require")
+
+    # The fallback should automatically target the direct Postgres port.
+    assert db._pool_fallback_label == "direct"
+    assert db._pool_conninfo_fallback is not None
+    parsed = urlparse(db._pool_conninfo_fallback)
+    assert parsed.port == 5432
+    assert parsed.hostname == "db.example.com"


### PR DESCRIPTION
## Summary
- Detect pgBouncer usage when the database URL is already pointed at port 6543 and build a direct Postgres fallback when no DIRECT_URL override exists
- Keep the pool diagnostics consistent while skipping duplicate fallback targets and document the behavior in the Codex changelog
- Add a regression test that locks in the inferred fallback wiring

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690d28c25580832a8735e31af13b9253