### PR TITLE
Handle pgBouncer disconnects with automatic failover

### DIFF
--- a/docs/CODEX_CHANGELOG.md
+++ b/docs/CODEX_CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Document noteworthy backend/front-end changes implemented via Codex tasks. Keep the newest entries at the top.
 
+## 2024-04-15 — Auto-failover after pgBouncer disconnects
+
+- Detect connection-level failures ("server closed the connection unexpectedly", etc.)
+  and automatically swap the async pool to the configured direct Postgres fallback so
+  repeated pgBouncer outages no longer exhaust the pool or leave the service in cache-only mode.
+- Extend the watchdog probe to trigger the same failover logic and centralize pool creation
+  helpers so both startup and runtime recovery paths reuse the hardened configuration.
+- Documented the behavior updates in `docs/OPERATIONS.md`. No front-end changes are needed
+  because the `/health` envelope and diagnostics contracts remain unchanged.
+
 ## 2024-04-14 — Stabilize health checks and cache fallbacks
 
 - Replaced the `/health` probe's `asyncio.wait_for` wrapper with a pool-scoped timeout so

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -8,6 +8,9 @@
 ## Render environment
 - `DATABASE_URL` should target the pgBouncer endpoint on port **6543** and include `sslmode=require` in the query string.
 - Restarting the service will automatically reopen the shared async connection pool during FastAPI startup.
+- When pgBouncer begins terminating connections the backend now automatically fails over to
+  the configured `DIRECT_URL` (if provided). Watch for `[DB] connection failure` log lines to
+  confirm the switch and ensure the direct connection remains reachable.
 
 ## Connectivity checks
 Run the following from a Render shell or any environment that has network access to Supabase:


### PR DESCRIPTION
## Summary
- detect connection failures from pgBouncer and automatically swap the async pool to the configured direct Postgres fallback
- reuse shared pool setup helpers and let the watchdog trigger the same failover path for runtime disconnects
- prevent the watchdog-triggered failover from cancelling and awaiting itself so the fallback pool can be installed reliably

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d549d1a3c832ab322d484b04ac02b)