### PR TITLE
Fail over to direct database on pgBouncer timeouts

### DIFF
--- a/docs/CODEX_CHANGELOG.md
+++ b/docs/CODEX_CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Document noteworthy backend/front-end changes implemented via Codex tasks. Keep the newest entries at the top.
 
+## 2024-04-16 — Fail over when pgBouncer stalls
+
+- Treat `PoolTimeout` events during connection acquisition as connectivity failures and
+  automatically switch the async pool to the direct Postgres fallback so the backend
+  recovers instead of staying in cache-only mode when pgBouncer is saturated or stops
+  accepting connections.
+- Allow the `/health` probe, feature handler, and ingestion pipeline to request the
+  fallback proactively so mobile clients stop seeing repeated `db:false` responses and
+  ingestion resumes without manual intervention after a stall.
+- Document the new behavior in `docs/OPERATIONS.md`. No front-end changes are required
+  because diagnostics already surface `cache_fallback` and `pool_timeout` for awareness.
+
 ## 2024-04-15 — Auto-failover after pgBouncer disconnects
 
 - Detect connection-level failures ("server closed the connection unexpectedly", etc.)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -11,6 +11,9 @@
 - When pgBouncer begins terminating connections the backend now automatically fails over to
   the configured `DIRECT_URL` (if provided). Watch for `[DB] connection failure` log lines to
   confirm the switch and ensure the direct connection remains reachable.
+- Pool acquisition timeouts are also treated as connection failures; the service now
+  proactively flips to the direct backend when pgBouncer stalls so `/health` and feature
+  handlers stop reporting `db:false` after a brief outage.
 
 ## Connectivity checks
 Run the following from a Render shell or any environment that has network access to Supabase:

--- a/tests/test_db_failover.py
+++ b/tests/test_db_failover.py
@@ -1,0 +1,85 @@
+import asyncio
+
+import pytest
+from psycopg_pool.errors import PoolTimeout
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _FailContext:
+    async def __aenter__(self):
+        raise PoolTimeout("timeout")
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _SuccessConn:
+    async def execute(self, query):  # noqa: ARG002 - interface shim
+        return None
+
+
+class _SuccessContext:
+    async def __aenter__(self):
+        return _SuccessConn()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FailPool:
+    def connection(self):
+        return _FailContext()
+
+    def get_stats(self):
+        return {"pool_size": 0, "pool_available": 0, "requests_waiting": 0}
+
+
+class _SuccessPool:
+    def connection(self):
+        return _SuccessContext()
+
+    def get_stats(self):
+        return {"pool_size": 1, "pool_available": 1, "requests_waiting": 0}
+
+
+@pytest.mark.anyio
+async def test_get_db_pool_timeout_triggers_failover(monkeypatch):
+    from app import db
+
+    # Reset globals to a known state for the fake pools
+    db._pool = _FailPool()  # type: ignore[assignment]
+    db._pool_open = True
+    db._pool_conninfo_fallback = "postgresql://fallback"
+    db._pool_fallback_label = "direct"
+    db._pool_primary_label = "pgbouncer"
+    db._pool_active_label = "pgbouncer"
+    db._pool_lock = asyncio.Lock()
+
+    failover_calls: list[str] = []
+
+    async def _fake_activate(reason: str) -> bool:
+        failover_calls.append(reason)
+        db._pool = _SuccessPool()  # type: ignore[assignment]
+        db._pool_open = True
+        db._pool_active_label = "direct"
+        return True
+
+    monkeypatch.setattr(db, "_activate_fallback_pool", _fake_activate)
+
+    try:
+        agen = db.get_db()
+        conn = await agen.__anext__()
+        assert isinstance(conn, _SuccessConn)
+        await agen.aclose()
+    finally:
+        db._pool = None
+        db._pool_open = False
+        db._pool_conninfo_fallback = None
+        db._pool_fallback_label = None
+        db._pool_active_label = "unknown"
+
+    assert failover_calls == ["pool timeout acquiring connection"]


### PR DESCRIPTION
## Summary
- treat pool acquisition timeouts as connection failures and expose helpers so callers can trigger the configured direct Postgres fallback
- update the health probe, features handler, and ingestion pipeline to request the fallback when pgBouncer stalls, preventing prolonged db:false responses
- document the new behavior and add coverage that ensures the failover path runs when a PoolTimeout occurs

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d7caaecc4832ab009af1951dc457c)