### PR TITLE
Fix database pool failover global bookkeeping

### DIFF
--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -209,6 +209,8 @@ def _is_connection_failure(exc: BaseException) -> bool:
 async def _activate_fallback_pool(reason: str) -> bool:
     """Switch to the configured fallback connection when possible."""
 
+    global _pool, _pool_open, _pool_active_label
+
     if not _pool_conninfo_fallback or not _pool_fallback_label:
         return False
     if _pool_active_label == _pool_fallback_label:
@@ -236,7 +238,6 @@ async def _activate_fallback_pool(reason: str) -> bool:
 
         await _stop_pool_monitors()
 
-        global _pool_open
         was_open = _pool_open
         _pool_open = False
 
@@ -362,7 +363,7 @@ def _get_or_create_pool() -> AsyncConnectionPool:
 
 
 async def open_pool() -> AsyncConnectionPool:
-    global _pool_open, _pool_last_refresh, _pool_active_label
+    global _pool, _pool_open, _pool_last_refresh, _pool_active_label
     async with _pool_lock:
         pool = _get_or_create_pool()
         if not _pool_open:

--- a/docs/CODEX_CHANGELOG.md
+++ b/docs/CODEX_CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Document noteworthy backend/front-end changes implemented via Codex tasks. Keep the newest entries at the top.
 
+## 2024-04-17 — Fix fallback activation regression
+
+- Restore the global bookkeeping inside the async pool failover helper so Python
+  no longer treats `_pool_active_label` as a local variable. The regression was
+  preventing the watchdog, `/health`, and feature handlers from switching to the
+  configured fallback backend after connection failures, leaving the service
+  stuck in cache-only mode with `db:false` responses.
+- Ensure the primary `open_pool` helper also updates the shared `_pool`
+  reference when the fallback opens during startup retries so future
+  acquisitions use the replacement pool.
+- Documented the fix here; diagnostics and response envelopes are unchanged, so
+  no mobile/front-end updates are required.
+
 ## 2024-04-16 — Fail over when pgBouncer stalls
 
 - Treat `PoolTimeout` events during connection acquisition as connectivity failures and


### PR DESCRIPTION
## Summary
- ensure the async pool failover helper updates the shared pool state instead of shadowing locals
- update open_pool to propagate the replacement pool when startup falls back to the direct backend
- document the regression fix in docs/CODEX_CHANGELOG.md

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d8543fa68832a9a90af8347401f84)