### PR TITLE
Expose cache diagnostics and background refresh scheduling

### DIFF
--- a/docs/CODEX_CHANGELOG.md
+++ b/docs/CODEX_CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Document noteworthy backend/front-end changes implemented via Codex tasks. Keep the newest entries at the top.
 
+## 2025-11-07 — Cache diagnostics and scheduled refreshes for features
+
+- Track cached snapshot age inside `/v1/features/today` diagnostics so clients can see
+  exactly when the last-good payload was recorded.
+- Force a mart refresh whenever the cached data is older than 15 minutes and otherwise
+  throttle background refresh scheduling to once every five minutes per user.
+- Document the new diagnostics fields and refresh cadence in `docs/FEATURES_ROUTE.md`
+  and `docs/DIAG_FEATURES.md`. No front-end changes are required beyond optionally
+  reading the new diagnostic flags.
+
 ## 2024-04-17 — Fix fallback activation regression
 
 - Restore the global bookkeeping inside the async pool failover helper so Python

--- a/docs/DIAG_FEATURES.md
+++ b/docs/DIAG_FEATURES.md
@@ -13,10 +13,12 @@ The response includes:
 
 - `features`: metadata about the most recent `/v1/features/today` query, including the requested user id, which branch (scoped vs. fallback) was used, and the latest `day`/`updated_at` timestamps.
   - `cache_fallback` and `pool_timeout` highlight when the handler served cached data because the database pool was saturated.
+  - `cache_hit` reports whether the cached snapshot was served immediately, while `cache_age_seconds` shows how old it was when returned.
   - `error` reflects the error message when the endpoint itself returned `ok:false`.
   - `last_error` captures the most recent failure that triggered a fallback so clients can log the cause without treating cached data as an outage.
   - `enrichment_errors` lists non-fatal enrichment steps (sleep, space weather, posts) that
     timed out but left the payload otherwise usable.
+  - `refresh_attempted`, `refresh_scheduled`, `refresh_reason`, and `refresh_forced` capture the background mart refresh cadence triggered by the request.
 - `tables`: row counts and latest timestamps for the tables that feed the feature rollup.
   - `marts.daily_features` shows the global feature mart freshness (`max_day` and `max_updated_at`).
   - `marts.schumann_daily` reports the latest Schumann resonance day available.


### PR DESCRIPTION
## Summary
- add cache age metadata and background refresh tracking to /v1/features/today diagnostics
- throttle mart refresh scheduling by tracking per-user intervals and forcing jobs when cached payloads grow stale
- document the new diagnostics fields and refresh cadence for mobile clients

## Testing
- pytest tests/api/test_features_today.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d988cd07c832ab7cd60da7c9e334f)