### PR TITLE
Add traceable diagnostics for feature payloads

### DIFF
--- a/docs/CODEX_CHANGELOG.md
+++ b/docs/CODEX_CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Document noteworthy backend/front-end changes implemented via Codex tasks. Keep the newest entries at the top.
 
+## 2025-11-09 — Trace features fallbacks and cache state
+
+- Added a timestamped `diagnostics.trace` log to `/v1/features/today` so engineers can copy
+  the execution path (mart lookups, cache fallbacks, refresh scheduling) from the mobile
+  debug console without relying on screenshots.
+- Surface lightweight `cache_snapshot_initial`, `cache_snapshot_final`, and
+  `payload_summary` blocks that call out which sections (health, sleep, space weather,
+  Schumann, posts) contained non-null data before and after the request.
+- Flag when the last-good cache is rewritten via `diagnostics.cache_updated` and update the
+  feature docs to explain the new fields.
+
 ## 2025-11-08 — Rehydrate empty feature payloads from cache
 
 - When the mart returns an empty snapshot but the last-good cache still holds data,

--- a/docs/DIAG_FEATURES.md
+++ b/docs/DIAG_FEATURES.md
@@ -15,6 +15,14 @@ The response includes:
   - `cache_fallback` and `pool_timeout` highlight when the handler served cached data because the database pool was saturated.
   - `cache_hit` reports whether the cached snapshot was served immediately, while `cache_age_seconds` shows how old it was when returned.
   - `cache_rehydrated` is `true` when the mart returned an empty payload but cached data was available and reused for the response.
+  - `cache_updated` flags when `/v1/features/today` wrote a new snapshot during the request and the
+    `cache_snapshot_initial` / `cache_snapshot_final` blocks summarize which sections (health,
+    sleep, space weather, Schumann, post copy) contained non-null values before and after the
+    handler ran.
+  - `payload_summary` provides the same snapshot for the payload returned to the caller so teams can
+    quickly confirm whether the health, sleep, or space-weather cards were populated.
+  - `trace` is a timestamped list of decision points (mart lookups, cache fallbacks, background
+    refreshes, etc.) that doubles as a copyable debug log in the mobile app.
   - `error` reflects the error message when the endpoint itself returned `ok:false`.
   - `last_error` captures the most recent failure that triggered a fallback so clients can log the cause without treating cached data as an outage.
   - `enrichment_errors` lists non-fatal enrichment steps (sleep, space weather, posts) that

--- a/docs/FEATURES_ROUTE.md
+++ b/docs/FEATURES_ROUTE.md
@@ -33,6 +33,11 @@ The `/v1/features/today` endpoint returns a consolidated “daily features” sn
     "cache_hit": true|false,
     "cache_age_seconds": float|null,
     "cache_rehydrated": true|false,
+    "cache_updated": true|false,
+    "cache_snapshot_initial": { ... },
+    "cache_snapshot_final": { ... },
+    "payload_summary": { ... },
+    "trace": ["2025-11-09T04:12:00Z fetched mart row", ...],
     "pool_timeout": true|false,
     "error": string|null,
     "last_error": string|null,
@@ -65,6 +70,16 @@ yesterday’s data.
 weather, Schumann resonance, etc.) that were skipped because they hit the short timeout.
 The handler still returns data, but these entries allow the UI to annotate partially
 freshened payloads.
+
+`diagnostics.cache_snapshot_initial` and `diagnostics.cache_snapshot_final` provide
+lightweight summaries of the cache state before and after the request, highlighting
+whether health, sleep, space-weather, or Schumann sections contained non-null values.
+`diagnostics.payload_summary` performs the same check on the payload returned to the
+client, while `diagnostics.cache_updated` flags when the handler wrote a new snapshot to
+the cache during the request. The `diagnostics.trace` array records timestamped steps in
+the decision tree (for example when a mart row loads, when cached data is reused, or when
+a background refresh is scheduled) so engineers can copy/paste a textual log instead of
+relying on screenshots of the debug overlay.
 
 ## Source selection
 


### PR DESCRIPTION
## Summary
- add a timestamped trace buffer and payload snapshot summaries inside `/v1/features/today`
- expose cache snapshot summaries, payload summaries, and refresh trace metadata through the diagnostics block
- document the new diagnostics fields so mobile teams can copy textual logs instead of screenshots

## Testing
- `pytest`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e589e662c832a8f43474f2f85c7aa)