### PR TITLE
Document diagnostics guidance for anonymous feature requests

### DIFF
--- a/docs/CODEX_CHANGELOG.md
+++ b/docs/CODEX_CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Document noteworthy backend/front-end changes implemented via Codex tasks. Keep the newest entries at the top.
 
+## 2025-11-10 — Document anonymous diagnostic troubleshooting
+
+- Added a troubleshooting note to `docs/DIAG_FEATURES.md` explaining how to interpret
+  `branch: "anonymous"` / `source: "empty"` diagnostics and pointing developers to the
+  required `X-Dev-UserId` header when using the developer bearer token. This prevents
+  confusing "empty" feature payloads when the app fails to scope requests to a user id.
+
 ## 2025-11-09 — Trace features fallbacks and cache state
 
 - Added a timestamped `diagnostics.trace` log to `/v1/features/today` so engineers can copy

--- a/docs/DIAG_FEATURES.md
+++ b/docs/DIAG_FEATURES.md
@@ -79,3 +79,12 @@ Example fragment:
 ## Optional diagnostics from `/v1/features/today`
 
 Append `?diag=1` to the existing `/v1/features/today` request to embed the same `features` diagnostic block alongside the data payload.
+
+## Troubleshooting common diagnostics
+
+- **`branch: "anonymous"` with `source: "empty"`** – The handler never resolved a user id for the request, so it short-circuited before
+  it could touch the mart or the cache. The trace will include the line `anonymous request - skipping user scoped lookups`, which
+  comes directly from the anonymous branch inside `_collect_features`.
+  Confirm that the caller is presenting a valid Supabase JWT or, when using the developer bearer token, that an `X-Dev-UserId`
+  header with a UUID value is attached. Without a scoped user id, `/v1/features/today` intentionally returns an empty payload and
+  the cards in the app will stay frozen. 【F:app/routers/summary.py†L983-L1007】【F:app/utils/auth.py†L46-L72】


### PR DESCRIPTION
## Summary
- document how to interpret the `branch: "anonymous"` and `source: "empty"` diagnostics in `docs/DIAG_FEATURES.md`
- note in the changelog that the diagnostics guide now points developers to the required `X-Dev-UserId` header when using the developer bearer token

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eb66a86b4832a899755bc735bfeb1)