### PR TITLE
Fix features endpoint connection acquisition

### DIFF
--- a/app/routers/summary.py
+++ b/app/routers/summary.py
@@ -115,25 +115,15 @@ def _diag_trace(diag_info: Dict[str, Any], message: str) -> None:
 async def _acquire_features_conn():
     """Acquire a database connection for the features endpoint."""
 
-    pool = await get_pool()
-    ctx = pool.connection()
-    conn = await ctx.__aenter__()
-    exit_type = exit_exc = exit_tb = None
-
+    agen = get_db()
     try:
-        await conn.execute(f"set statement_timeout = {STATEMENT_TIMEOUT_MS}")
-
         try:
-            yield conn
-        except BaseException as exc:
-            exit_type, exit_exc, exit_tb = type(exc), exc, exc.__traceback__
-            raise
-    except BaseException as exc:
-        if exit_exc is None:
-            exit_type, exit_exc, exit_tb = type(exc), exc, exc.__traceback__
-        raise
+            conn = await agen.__anext__()
+        except StopAsyncIteration:  # pragma: no cover - defensive guard
+            raise RuntimeError("database dependency yielded no connection")
+        yield conn
     finally:
-        await ctx.__aexit__(exit_type, exit_exc, exit_tb)
+        await agen.aclose()
 
 
 _refresh_registry: Dict[str, float] = {}

--- a/docs/CODEX_CHANGELOG.md
+++ b/docs/CODEX_CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Document noteworthy backend/front-end changes implemented via Codex tasks. Keep the newest entries at the top.
 
+## 2025-11-15 — Reuse resilient DB dependency for features
+
+- Updated the `/v1/features/today` connection helper to reuse the shared
+  `get_db` dependency so the endpoint now benefits from the same retry and
+  failover logic as the rest of the API.
+- Eliminated ad-hoc pool acquisition that was surfacing repeated
+  `pool_timeout` diagnostics and forcing the app to serve cached data even
+  while ingestion succeeded.
+- No front-end changes are required; the fix keeps diagnostics consistent
+  while restoring live snapshots once a connection becomes available.
+
 ## 2025-11-14 — Harden `/db/ping` failover handling
 
 - Taught the `GET /db/ping` endpoint to retry connection attempts while invoking the


### PR DESCRIPTION
## Summary
- reuse the shared get_db dependency inside /v1/features/today so it inherits retry/failover behavior and stops spurious pool timeouts
- document the change in CODEX_CHANGELOG

## Testing
- pytest tests/api/test_features_today.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f65d0d048832a9452f0ad4a563815)