### PR TITLE
Add DB health monitor, failover guard, and routing safeguards

### DIFF
--- a/app/db/health.py
+++ b/app/db/health.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from psycopg_pool import PoolTimeout
+
+from . import (
+    get_pool,
+    get_pool_metrics,
+    handle_connection_failure,
+    handle_pool_timeout,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class DBHealthMonitor:
+    """Background task that tracks database availability with hysteresis."""
+
+    _PROBE_INTERVAL_SECONDS = 3.0
+    _PROBE_TIMEOUT_SECONDS = 0.3
+    _REQUIRED_SUCCESSES = 2
+    _REQUIRED_FAILURES = 2
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._task: Optional[asyncio.Task] = None
+        self._db_ok: bool = True
+        now = datetime.now(timezone.utc)
+        self._since: datetime = now
+        self._last_change: datetime = now
+        self._last_probe: Optional[datetime] = None
+        self._consec_ok: int = 0
+        self._consec_fail: int = 0
+        self._stopped = asyncio.Event()
+
+    async def start(self) -> None:
+        async with self._lock:
+            if self._task is None or self._task.done():
+                self._stopped.clear()
+                self._task = asyncio.create_task(self._run(), name="db-health-monitor")
+
+    async def stop(self) -> None:
+        async with self._lock:
+            task = self._task
+            if not task:
+                return
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            finally:
+                self._task = None
+                self._stopped.set()
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                await self._probe_once()
+                await asyncio.sleep(self._PROBE_INTERVAL_SECONDS)
+        except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+            raise
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("[HEALTH] monitor loop crashed")
+
+    async def _probe_once(self) -> None:
+        success = False
+        try:
+            pool = await get_pool()
+            async with pool.connection(timeout=self._PROBE_TIMEOUT_SECONDS) as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute("select 1;")
+            success = True
+        except PoolTimeout as exc:
+            await handle_pool_timeout("health monitor timeout")
+            logger.warning("[HEALTH] monitor pool timeout: %s", exc)
+        except Exception as exc:
+            await handle_connection_failure(exc)
+            logger.warning("[HEALTH] monitor probe failed: %s", exc)
+        finally:
+            self._record_probe(success)
+
+    def _record_probe(self, success: bool) -> None:
+        now = datetime.now(timezone.utc)
+        self._last_probe = now
+        if success:
+            self._consec_ok += 1
+            self._consec_fail = 0
+            if not self._db_ok and self._consec_ok >= self._REQUIRED_SUCCESSES:
+                self._set_state(True, now, reason=f"consec_ok={self._consec_ok}")
+        else:
+            self._consec_fail += 1
+            self._consec_ok = 0
+            if self._db_ok and self._consec_fail >= self._REQUIRED_FAILURES:
+                self._set_state(False, now, reason=f"consec_fail={self._consec_fail}")
+
+    def _set_state(self, ok: bool, when: datetime, *, reason: str) -> None:
+        self._db_ok = ok
+        self._since = when
+        self._last_change = when
+        if ok:
+            logger.info("[HEALTH] db=True  (%s)", reason)
+        else:
+            logger.warning("[HEALTH] db=False (%s)", reason)
+
+    def get_db_ok(self) -> bool:
+        return self._db_ok
+
+    def get_sticky_age_ms(self) -> int:
+        base = self._since if self._since else datetime.now(timezone.utc)
+        delta = datetime.now(timezone.utc) - base
+        return int(delta.total_seconds() * 1000)
+
+    def snapshot(self) -> Dict[str, Any]:
+        since_iso = self._since.isoformat()
+        last_change_iso = self._last_change.isoformat()
+        pool_metrics = get_pool_metrics()
+        return {
+            "db_ok": self._db_ok,
+            "since": since_iso,
+            "last_change": last_change_iso,
+            "consec_ok": self._consec_ok,
+            "consec_fail": self._consec_fail,
+            "last_probe": self._last_probe.isoformat() if self._last_probe else None,
+            "sticky_age_ms": self.get_sticky_age_ms(),
+            "pool_backend": pool_metrics.get("backend"),
+        }
+
+
+_health_monitor: Optional[DBHealthMonitor] = None
+
+
+def get_health_monitor() -> Optional[DBHealthMonitor]:
+    return _health_monitor
+
+
+async def ensure_health_monitor_started() -> DBHealthMonitor:
+    global _health_monitor
+    if _health_monitor is None:
+        _health_monitor = DBHealthMonitor()
+    await _health_monitor.start()
+    return _health_monitor
+
+
+async def stop_health_monitor() -> None:
+    monitor = _health_monitor
+    if monitor is not None:
+        await monitor.stop()

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,10 @@
 import logging
-from datetime import datetime, timezone
-from time import monotonic
 
 from fastapi import FastAPI, Depends, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from psycopg_pool import PoolTimeout
 
-from .routers import ingest, summary, symptoms
+from .routers import health as health_router, ingest, summary, symptoms
  # Resilient imports for optional/relocated modules
 try:
     # Preferred layout: app/api/...
@@ -25,13 +22,8 @@ except ModuleNotFoundError:
     except ModuleNotFoundError:
         webhooks_router = None
 from .utils.auth import require_auth as ensure_authenticated
-from .db import (
-    get_pool,
-    open_pool,
-    close_pool,
-    handle_connection_failure,
-    handle_pool_timeout,
-)
+from .db import get_pool, open_pool, close_pool
+from .db.health import ensure_health_monitor_started, stop_health_monitor
 
 
 logger = logging.getLogger(__name__)
@@ -80,12 +72,19 @@ async def _check_db_ready():
         logger.exception("[DB] startup check failed: %s", exc)
 
 
+@app.on_event("startup")
+async def _start_health_monitor():
+    await ensure_health_monitor_started()
+
+
 @app.on_event("shutdown")
 async def _close_pool():
     await close_pool()
 
-# Build marker for health checks (update per deploy or wire to your CI SHA)
-BUILD = "2025-09-20T02:45Z"
+
+@app.on_event("shutdown")
+async def _stop_health_monitor():
+    await stop_health_monitor()
 
 app.add_middleware(
     CORSMiddleware,
@@ -100,85 +99,12 @@ if WebhookSigMiddleware is not None:
     app.add_middleware(WebhookSigMiddleware)
 
 
-_DB_PROBE_TIMEOUT = 0.6
-_DB_STICKY_GRACE_SECONDS = 30.0
-_last_db_status: bool = True
-_last_db_status_ts: float = monotonic()
-
-
-async def _health_db_probe() -> tuple[bool, int, int]:
-    global _last_db_status, _last_db_status_ts
-
-    start = monotonic()
-    probe_ok = False
-    error_detail: str | None = None
-
-    for attempt in range(2):
-        try:
-            pool = await get_pool()
-            async with pool.connection(timeout=_DB_PROBE_TIMEOUT):
-                probe_ok = True
-                error_detail = None
-                break
-        except PoolTimeout:
-            error_detail = "pool timeout"
-            did_failover = await handle_pool_timeout("health probe pool timeout")
-            if did_failover and attempt == 0:
-                continue
-            break
-        except Exception as exc:  # pragma: no cover - defensive logging
-            error_detail = str(exc)
-            did_failover = await handle_connection_failure(exc)
-            if did_failover and attempt == 0:
-                continue
-            break
-
-    duration_ms = int((monotonic() - start) * 1000)
-    now = monotonic()
-
-    if probe_ok:
-        _last_db_status = True
-        _last_db_status_ts = now
-        logger.info("[HEALTH] db probe ok latency=%dms", duration_ms)
-        return True, 0, duration_ms
-
-    age_seconds = now - _last_db_status_ts
-    if age_seconds > _DB_STICKY_GRACE_SECONDS:
-        _last_db_status = False
-        _last_db_status_ts = now
-        logger.warning(
-            "[HEALTH] db probe failed after %dms: %s",
-            duration_ms,
-            error_detail or "unknown",
-        )
-        return False, 0, duration_ms
-
-    sticky_age_ms = int(age_seconds * 1000)
-    logger.warning(
-        "[HEALTH] db probe failed after %dms (sticky %dms): %s",
-        duration_ms,
-        sticky_age_ms,
-        error_detail or "unknown",
-    )
-    return _last_db_status, sticky_age_ms, duration_ms
-
-
-@app.get("/health")
-async def health():
-    db_status, sticky_age_ms, latency_ms = await _health_db_probe()
-    return {
-        "ok": True,
-        "service": "gaiaeyes-backend",
-        "build": BUILD,
-        "time": datetime.now(timezone.utc).isoformat(),
-        "db": db_status,
-        "db_sticky_age": sticky_age_ms,
-        "db_latency_ms": latency_ms,
-    }
-
 # ---- Simple bearer auth for /v1/*
 async def require_auth(request: Request):
     await ensure_authenticated(request)
+
+# Public health endpoint
+app.include_router(health_router.router)
 
 # Mount routers WITH /v1 prefix and the auth dependency
 app.include_router(ingest.router, prefix="/v1", dependencies=[Depends(require_auth)])

--- a/app/routers/health.py
+++ b/app/routers/health.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter
+
+from app.db.health import get_health_monitor
+
+
+router = APIRouter()
+
+
+@router.get("/health", include_in_schema=False)
+async def service_health() -> Dict[str, Any]:
+    monitor = get_health_monitor()
+    snapshot: Optional[Dict[str, Any]] = monitor.snapshot() if monitor else None
+    db_ok = bool(snapshot.get("db_ok")) if snapshot else True
+    sticky_age = int(snapshot.get("sticky_age_ms", 0)) if snapshot else 0
+
+    response: Dict[str, Any] = {
+        "ok": True,
+        "service": "gaiaeyes-backend",
+        "time": datetime.now(timezone.utc).isoformat(),
+        "db": db_ok,
+        "db_sticky_age": sticky_age,
+    }
+
+    if snapshot is not None:
+        response["monitor"] = snapshot
+
+    return response


### PR DESCRIPTION
## Summary
- add a hysteresis-based asynchronous DB health monitor with a public /health endpoint
- harden the async pool by tracking consecutive timeouts and logging backend transitions
- gate ingest and feature routes on DB health, add delayed mart refresh scheduling, and enrich diagnostics

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f7a286880832a8dbee11d240f31e5)