### PR TITLE
Refine aurora orthographic overlays

### DIFF
--- a/docs/codex_changelog.md
+++ b/docs/codex_changelog.md
@@ -1,0 +1,5 @@
+# Aurora tracker orthographic overlay updates
+
+- Refined both MU and theme fallback aurora detail templates to use the hemisphere-aware orthographic projection with safe-radius culling, sanitized path construction, and polar grid overlays.
+- Adjusted UI interactions so the KP Lines control toggles the live viewline visibility without navigating away, while metrics now suppress quiet-sky zeros and clamp mean probability displays to ≤100%.
+- Synced fallback overlay rendering, including the polar alignment guides and hemisphere-specific base-map swapping, to match the primary implementation.


### PR DESCRIPTION
## Summary
- add polar alignment grid and safe-radius orthographic projection to the aurora detail templates while sanitizing far-side coordinates
- adjust metrics rendering to suppress quiet-sky zeroes and clamp mean probability percentages along with a functional KP Lines toggle
- mirror the projection, toggle, and base-map updates inside the theme fallback and record the changes in the Codex changelog

## Testing
- php -l wp-content/mu-plugins/templates/gaiaeyes-aurora-detail.php
- php -l wp-content/themes/neve/partials/gaiaeyes-aurora-detail.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138bb5710c832ab7f79dc50e0308c2)