### PR TITLE
Fix south aurora isoline traversal

### DIFF
--- a/docs/web/codex_changelog.md
+++ b/docs/web/codex_changelog.md
@@ -1,0 +1,8 @@
+# Web Codex Change Log
+
+Document noteworthy web-facing changes implemented via Codex tasks. Keep the newest entries at the top.
+
+## 2025-11-12 — Fix OVATION south grid isolines
+
+- Corrected the south hemisphere OVATION grid traversal so probability contours and Kp isolines scan latitude rows from 0° down to −90°.
+- Ensured viewline and Kp isolines share the same latitude orientation, restoring contours near −60° to −75° instead of near the equator.

--- a/wp-content/mu-plugins/gaia-aurora.php
+++ b/wp-content/mu-plugins/gaia-aurora.php
@@ -833,12 +833,23 @@ function gaia_isoline_southmost($grid, $pstar, $hemi)
     if ($row_start < 0) {
         return $coords;
     }
-    if ($hemi === 'north') {
-        $row_end = 0;
-        $step = -1;
-    } else {
+
+    if ($hemi === 'south') {
+        $row_start = 90;
+        if ($row_start >= $rows) {
+            $row_start = $rows - 1;
+        }
         $row_end = min($rows - 1, 180);
+        if ($row_start > $row_end) {
+            $row_start = $row_end;
+        }
         $step = 1;
+    } else {
+        $row_end = 0;
+        if ($row_start < $row_end) {
+            $row_start = $row_end;
+        }
+        $step = -1;
     }
 
     for ($lon = 0; $lon < $cols; $lon++) {


### PR DESCRIPTION
## Summary
- correct the OVATION south grid traversal so isolines walk latitude rows from 0° toward −90°
- ensure south viewline and Kp isolines share the same latitude orientation and document the fix in the web Codex changelog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913db210fac832a949de96820a86b7a)