### PR TITLE
Add lat/lon keys to drap absorption schema

### DIFF
--- a/docs/CODEX_CHANGELOG.md
+++ b/docs/CODEX_CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Document noteworthy backend/front-end changes implemented via Codex tasks. Keep the newest entries at the top.
 
+## 2025-11-25 — DRAP grid parsing + solar-cycle mapping
+
+- Updated `scripts/ingest_space_forecasts_step1.py` so the D-RAP text product is parsed
+  as a latitude/longitude grid with flattened rows stored in `ext.drap_absorption`
+  and corresponding daily rollups in `marts.drap_absorption_daily`.
+- Corrected the solar-cycle ingest to map `time-tag` to first-of-month dates and to
+  read the `predicted_ssn` and `predicted_f10.7` fields from the live SWPC JSON feed,
+  ensuring rows land consistently in `ext.solar_cycle_forecast` and `marts.solar_cycle_progress`.
+- Documented the new parsing behavior in `docs/SCRIPTS_GUIDE.md`.
+
 ## 2025-11-24 — Fix initial symptom mart refresh
 
 - Updated `20251019140000_setup_symptom_domain.sql` to run the first `symptom_daily` and

--- a/docs/SCRIPTS_GUIDE.md
+++ b/docs/SCRIPTS_GUIDE.md
@@ -63,6 +63,12 @@ This guide documents the maintenance and data-processing scripts located in [`/s
 
 > SuperMAG magnetometer data are provided courtesy of SuperMAG, Johns Hopkins University Applied Physics Laboratory. Cite their contribution on dashboards or downstream artifacts that surface the indices.
 
+### Step 1 dataset notes
+
+**D-RAP absorption grid** – `ingest_space_forecasts_step1.py` fetches `https://services.swpc.noaa.gov/text/drap_global_frequencies.txt`, extracts the “Product Valid At” timestamp, longitude header, and every latitude row, and flattens the lat/lon grid into `ext.drap_absorption`. Each grid cell is labeled as the `global` region with the 10 MHz carrier (or the frequency declared in the header) plus the parsed absorption dB value; the script then rolls the day’s grid into `marts.drap_absorption_daily` (max + average absorption per day/region).
+
+**Solar-cycle predictions** – The same script ingests `https://services.swpc.noaa.gov/json/solar-cycle/predicted-solar-cycle.json`, treating each object’s `time-tag` (`YYYY-MM`) as the first day of that month for `forecast_month`. The feed’s `predicted_ssn` and `predicted_f10.7` fields populate `sunspot_number` and `f10_7_flux` respectively, with the `issued_at` column filled from `issueTime` when present (or left NULL otherwise) in both `ext.solar_cycle_forecast` and `marts.solar_cycle_progress`.
+
 ## Adding new scripts
 
 When adding to `/scripts`:

--- a/supabase/migrations/20250204120000_extend_drap_absorption_grid.sql
+++ b/supabase/migrations/20250204120000_extend_drap_absorption_grid.sql
@@ -1,0 +1,21 @@
+begin;
+
+alter table if exists ext.drap_absorption
+    add column if not exists lat numeric,
+    add column if not exists lon numeric,
+    add column if not exists lat_key text generated always as (coalesce(lat::text, 'na')) stored,
+    add column if not exists lon_key text generated always as (coalesce(lon::text, 'na')) stored;
+
+alter table if exists ext.drap_absorption
+    drop constraint if exists drap_absorption_pkey;
+
+alter table if exists ext.drap_absorption
+    add constraint drap_absorption_pkey primary key (
+        ts_utc,
+        region_key,
+        frequency_key,
+        lat_key,
+        lon_key
+    );
+
+commit;


### PR DESCRIPTION
## Summary
- add numeric latitude/longitude columns and generated keys to `ext.drap_absorption`, and update the primary key so the new DRAP grid rows can be stored without schema errors

## Testing
- pytest tests/test_space_forecast_ingest.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69180ce6123c832a8d8935ee65c36be7)