### PR TITLE
Update space visuals workflow to upload to Supabase

### DIFF
--- a/.github/workflows/space-visuals.yml
+++ b/.github/workflows/space-visuals.yml
@@ -36,6 +36,7 @@ jobs:
         env:
           OUTPUT_JSON_PATH: ${{ github.workspace }}/gaiaeyes-media/data/space_live.json
           MEDIA_DIR: ${{ github.workspace }}/gaiaeyes-media
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
           python3 scripts/space_visuals_ingest.py
       - name: Commit & push (images + space_live.json)


### PR DESCRIPTION
## Summary
- add Supabase database URL secret to the space visuals ingestion workflow so uploads are written to the database

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b9e107d28832a95d7732960618144)