### PR TITLE
Align /v1/space/visuals with visuals media base and items array

### DIFF
--- a/app/routers/space_visuals.py
+++ b/app/routers/space_visuals.py
@@ -12,11 +12,16 @@ from app.db import get_db
 
 router = APIRouter(prefix="/v1")
 
+# Legacy default (GitHub) remains as last resort
 _DEFAULT_MEDIA_BASE = "https://cdn.jsdelivr.net/gh/GaiaEyesHQ/gaiaeyes-media@main"
 
 
 def _media_base() -> str:
-    base = getenv("MEDIA_BASE_URL") or _DEFAULT_MEDIA_BASE
+    """
+    Prefer a visuals-specific base if provided; fall back to legacy MEDIA_BASE_URL; then default.
+    This allows visuals to use Supabase while other parts of the stack continue using the GitHub base.
+    """
+    base = getenv("VISUALS_MEDIA_BASE_URL") or getenv("MEDIA_BASE_URL") or _DEFAULT_MEDIA_BASE
     return base.rstrip("/")
 
 
@@ -49,11 +54,29 @@ def _ensure_list(value: Any) -> List[Dict[str, Any]]:
     return []
 
 
+def _to_relative(url: str | None, base: str | None) -> str | None:
+    """
+    If `url` starts with `base`, strip it to a leading-slash relative path.
+    If `url` is already relative, normalize to start with '/'.
+    Otherwise, return the original absolute URL.
+    """
+    if not url:
+        return None
+    if base and isinstance(url, str) and url.startswith(base):
+        rest = url[len(base):]
+        return rest if rest.startswith("/") else f"/{rest}"
+    # Already relative?
+    if "://" not in url:
+        return url if url.startswith("/") else f"/{url}"
+    return url
+
+
 @router.get("/space/visuals")
 async def space_visuals(conn=Depends(get_db)):
     media_base = _media_base()
     try:
         async with conn.cursor(row_factory=dict_row) as cur:
+            # Latest record per (asset_type, key)
             await cur.execute(
                 """
                 select distinct on (asset_type, key)
@@ -86,11 +109,14 @@ async def space_visuals(conn=Depends(get_db)):
         iso_ts = _iso(ts)
         if iso_ts and (latest_ts is None or iso_ts > latest_ts):
             latest_ts = iso_ts
+
         flags = _ensure_json(row.get("feature_flags"))
         for key, value in flags.items():
             if value:
                 overlay_flags[key] = True
+
         meta = _ensure_json(row.get("meta"))
+
         if asset_type == "series":
             samples = _ensure_list(row.get("series"))
             series.append(
@@ -105,10 +131,16 @@ async def space_visuals(conn=Depends(get_db)):
                 }
             )
             continue
-        rel_path = row.get("image_path") or ""
+
+        rel_path = (row.get("image_path") or "").lstrip("/")
         url = meta.get("url")
-        if not url and rel_path:
-            url = f"{media_base}/{rel_path.lstrip('/')}"
+        if url:
+            url = _to_relative(url, media_base)
+        elif rel_path:
+            url = f"/{rel_path}"
+        else:
+            url = None
+
         images.append(
             {
                 "key": row.get("key"),
@@ -126,10 +158,39 @@ async def space_visuals(conn=Depends(get_db)):
     images.sort(key=lambda item: (item.get("key") or "", item.get("captured_at") or ""))
     series.sort(key=lambda item: item.get("key") or "")
 
+    # Unified items array (new) — keeps legacy fields too
+    items: List[Dict[str, Any]] = []
+    for img in images:
+        items.append(
+            {
+                "id": img.get("key") or img.get("asset_type") or "image",
+                "title": (img.get("meta") or {}).get("title") or img.get("key"),
+                "credit": img.get("credit"),
+                "url": img.get("url") or (f"/{(img.get('image_path') or '').lstrip('/')}" if img.get("image_path") else ""),
+                "meta": (img.get("meta") or {}) | {"captured_at": img.get("captured_at")},
+            }
+        )
+    for s in series:
+        key = s.get("key") or "series"
+        samples = s.get("samples") or []
+        items.append(
+            {
+                "id": key,
+                "title": key,
+                "credit": s.get("credit"),
+                "url": "",
+                "series": {key: samples},
+                "meta": (s.get("meta") or {}) | {"captured_at": s.get("captured_at")},
+            }
+        )
+
     return {
         "ok": True,
+        "schema_version": 1,
+        "cdn_base": media_base,
         "generated_at": latest_ts,
         "images": images,
         "series": series,
         "feature_flags": overlay_flags,
+        "items": items,
     }

--- a/docs/codex_changelog.md
+++ b/docs/codex_changelog.md
@@ -2,6 +2,17 @@
 
 Document noteworthy backend/front-end changes implemented via Codex tasks. Keep the newest entries at the top.
 
+## 2025-12-05 — Space visuals Supabase alignment
+
+- Reworked `/v1/space/visuals` to prefer the new `VISUALS_MEDIA_BASE_URL` while keeping the
+  existing `MEDIA_BASE_URL` as a fallback and emitting relative URLs when the media base
+  matches.
+- Added `schema_version`, `cdn_base`, and a unified `items` array to the response while
+  preserving the legacy `images`/`series` shape for existing clients.
+- Normalized URL handling so Supabase-hosted media returns client-resolvable relative paths
+  and the endpoint continues to expose overlay feature flags and metadata alongside imagery
+  and series samples.
+
 ## 2025-12-04 — Space visuals workflow cleanup
 
 - Updated the `space-visuals` GitHub Action to install Python dependencies (including


### PR DESCRIPTION
## Summary
- prefer VISUALS_MEDIA_BASE_URL for space visuals while preserving existing MEDIA_BASE_URL fallback
- emit relative URLs when the visuals media base matches and include schema_version/cdn_base metadata
- add unified items array alongside legacy images/series fields and document the change in the Codex changelog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c10d6a2f4832a9792065cb98aa0d7)