### PR TITLE
Add Supabase storage uploads for space visuals workflow

### DIFF
--- a/.github/workflows/space-visuals.yml
+++ b/.github/workflows/space-visuals.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install requests pillow "psycopg[binary]"
       - name: Clean space images directory
         run: |
           rm -rf gaiaeyes-media/images/space/*
@@ -39,6 +40,15 @@ jobs:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
           python3 scripts/space_visuals_ingest.py
+      - name: Upload images to Supabase Storage
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          BUCKET: space-visuals
+          MEDIA_DIR: ${{ github.workspace }}/gaiaeyes-media
+          OUTPUT_JSON_PATH: ${{ github.workspace }}/gaiaeyes-media/data/space_live.json
+        run: |
+          python3 scripts/space_visuals_upload_to_supabase.py
       - name: Commit & push (images + space_live.json)
         run: |
           set -euo pipefail

--- a/app/utils/supabase_storage.py
+++ b/app/utils/supabase_storage.py
@@ -1,0 +1,46 @@
+import mimetypes
+import os
+from typing import Optional
+
+import requests
+
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SERVICE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+BUCKET = os.getenv("BUCKET", "space-visuals")
+
+
+class SupabaseUploadError(Exception):
+    pass
+
+
+def _public_url(path_key: str) -> str:
+    return f"{SUPABASE_URL}/storage/v1/object/public/{BUCKET}/{path_key.lstrip('/')}"
+
+
+def upload_bytes(
+    path_key: str,
+    data: bytes,
+    content_type: Optional[str] = None,
+    cache_control: str = "public, max-age=300",
+) -> str:
+    if not SUPABASE_URL or not SERVICE_KEY:
+        raise SupabaseUploadError("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+    if not content_type:
+        content_type = mimetypes.guess_type(path_key)[0] or "application/octet-stream"
+    url = f"{SUPABASE_URL}/storage/v1/object/{BUCKET}/{path_key.lstrip('/')}"
+    headers = {
+        "Authorization": f"Bearer {SERVICE_KEY}",
+        "Content-Type": content_type,
+        "x-upsert": "true",
+        "cache-control": cache_control,
+    }
+    resp = requests.post(url, headers=headers, data=data, timeout=60)
+    if not (200 <= resp.status_code < 300):
+        raise SupabaseUploadError(f"Upload failed {resp.status_code}: {resp.text[:200]}")
+    return _public_url(path_key)
+
+
+def upload_alias(latest_key: str, source_public_url: str, content_type: Optional[str] = None) -> str:
+    r = requests.get(source_public_url, timeout=60)
+    r.raise_for_status()
+    return upload_bytes(latest_key, r.content, content_type=content_type)

--- a/scripts/ingest_space_visuals.py
+++ b/scripts/ingest_space_visuals.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Supabase ingestion helpers for deterministic space visuals uploads."""
+
+from __future__ import annotations
+
+import datetime as dt
+import io
+import json
+import os
+from typing import Optional
+
+import requests
+from PIL import Image
+from psycopg import connect
+
+from app.utils.supabase_storage import _public_url, upload_alias, upload_bytes
+
+DB_URL = os.getenv("DIRECT_URL") or os.getenv("DATABASE_URL")
+
+
+def _stamp(ts: dt.datetime) -> str:
+    return ts.astimezone(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def upsert_visual_row(
+    key: str,
+    rel_path: str,
+    credit: str,
+    instrument: str,
+    captured_at: dt.datetime,
+    feature_flags: Optional[dict] | None = None,
+    meta_extra: Optional[dict] | None = None,
+):
+    meta = {"capture_stamp": _stamp(captured_at), "relative_path": rel_path, "title": key}
+    if meta_extra:
+        meta.update(meta_extra)
+    flags = feature_flags or {}
+    with connect(DB_URL) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+          insert into ext.space_visuals (ts, key, asset_type, image_path, meta, feature_flags, instrument, credit)
+          values (now(), %s, 'image', %s, %s::jsonb, %s::jsonb, %s, %s)
+        """,
+            (key, rel_path, json.dumps(meta), json.dumps(flags), instrument, credit),
+        )
+        conn.commit()
+
+
+# DRAP (mirror)
+def ingest_drap_now(captured_at: dt.datetime):
+    src = "https://services.swpc.noaa.gov/images/d-rap/global_d-rap_latest.png"
+    r = requests.get(src, timeout=60)
+    r.raise_for_status()
+    rel = f"drap/drap_{_stamp(captured_at)}.png"
+    public = upload_bytes(rel, r.content, content_type="image/png")
+    upload_alias("drap/latest.png", public, content_type="image/png")
+    upsert_visual_row("drap", rel, "NOAA/SWPC", "drap", captured_at)
+
+
+# LASCO C2 (mirror)
+def ingest_lasco_c2(captured_at: dt.datetime):
+    src = "https://soho.nascom.nasa.gov/data/LATEST/images/c2/latest.jpg"
+    r = requests.get(src, timeout=60)
+    r.raise_for_status()
+    rel = f"nasa/lasco_c2/lasco_c2_{_stamp(captured_at)}.jpg"
+    public = upload_bytes(rel, r.content, content_type="image/jpeg")
+    upload_alias("nasa/lasco_c2/latest.jpg", public, content_type="image/jpeg")
+    upsert_visual_row("lasco_c2", rel, "SOHO/LASCO", "lasco_c2", captured_at)
+
+
+# AIA 304 (mirror)
+def ingest_aia_304(captured_at: dt.datetime):
+    src = "https://sdo.gsfc.nasa.gov/assets/img/browse/latest/SDO_AIA_304.jpg"
+    r = requests.get(src, timeout=60)
+    r.raise_for_status()
+    rel = f"nasa/aia_304/aia_304_{_stamp(captured_at)}.jpg"
+    public = upload_bytes(rel, r.content, content_type="image/jpeg")
+    upload_alias("nasa/aia_304/latest.jpg", public, content_type="image/jpeg")
+    upsert_visual_row("aia_304", rel, "SDO/AIA", "aia_304", captured_at)
+
+
+# Aurora viewline (use your stored URLs if you already fetch them; otherwise just alias)
+def alias_aurora_viewline(tonight_url: Optional[str], tomorrow_url: Optional[str], ts: dt.datetime):
+    # If your ingest computes/pulls these PNGs elsewhere, re-upload via deterministic rel keys (aurora/viewline/…)
+    if tonight_url:
+        r = requests.get(tonight_url, timeout=60)
+        r.raise_for_status()
+        rel = f"aurora/viewline/tonight-north_{_stamp(ts)}.png"
+        public = upload_bytes(rel, r.content, content_type="image/png")
+        upload_alias("aurora/viewline/tonight-north.png", public, content_type="image/png")
+        upsert_visual_row("aurora_viewline_tonight", rel, "NOAA/SWPC OVATION", "ovation", ts)
+    if tomorrow_url:
+        r = requests.get(tomorrow_url, timeout=60)
+        r.raise_for_status()
+        rel = f"aurora/viewline/tomorrow-north_{_stamp(ts)}.png"
+        public = upload_bytes(rel, r.content, content_type="image/png")
+        upload_alias("aurora/viewline/tomorrow-north.png", public, content_type="image/png")
+        upsert_visual_row("aurora_viewline_tomorrow", rel, "NOAA/SWPC OVATION", "ovation", ts)
+
+
+# (Optional) If you render a custom PNG (e.g., "a_station") via PIL:
+def upload_rendered_png(
+    img: Image.Image,
+    key: str,
+    captured_at: dt.datetime,
+    subfolder: str,
+    credit: str,
+    instrument: str,
+):
+    rel = f"{subfolder}/{key}_{_stamp(captured_at)}.png"
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    public = upload_bytes(rel, buf.getvalue(), content_type="image/png")
+    upload_alias(f"{subfolder}/{key}_latest.png", public, content_type="image/png")
+    upsert_visual_row(key, rel, credit, instrument, captured_at)
+
+
+__all__ = [
+    "_public_url",
+    "alias_aurora_viewline",
+    "ingest_aia_304",
+    "ingest_drap_now",
+    "ingest_lasco_c2",
+    "upload_rendered_png",
+    "upload_alias",
+    "upload_bytes",
+    "upsert_visual_row",
+]

--- a/scripts/space_visuals_upload_to_supabase.py
+++ b/scripts/space_visuals_upload_to_supabase.py
@@ -1,0 +1,57 @@
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+from scripts.supabase_storage import upload_file
+
+MEDIA_DIR = Path(os.getenv("MEDIA_DIR", "gaiaeyes-media"))
+IMAGES_DIR = MEDIA_DIR / "images" / "space"
+# Kept for parity with ingest configuration; currently unused in upload flow
+SPACE_JSON = Path(os.getenv("OUTPUT_JSON_PATH", MEDIA_DIR / "data" / "space_live.json"))
+
+
+def map_dest(path: Path) -> str:
+    name = path.name.lower()
+    if "d-rap" in name or "drap" in name:
+        return "drap/latest.png"
+    if "lasco" in name and name.endswith(".jpg"):
+        return "nasa/lasco_c2/latest.jpg"
+    if ("aia_304" in name or "sdo_aia_304" in name) and name.endswith(".jpg"):
+        return "nasa/aia_304/latest.jpg"
+    if "tonight" in name and "viewline" in str(path.parent).lower():
+        return "aurora/viewline/tonight-north.png"
+    if "tomorrow" in name and "viewline" in str(path.parent).lower():
+        return "aurora/viewline/tomorrow-north.png"
+    return f"images/space/{path.name}"
+
+
+def main() -> int:
+    if not IMAGES_DIR.exists():
+        print(f"[upload] nothing to upload; missing {IMAGES_DIR}", file=sys.stderr)
+        return 0
+
+    files = sorted(glob.glob(str(IMAGES_DIR / "*")))
+    if not files:
+        print(f"[upload] no files in {IMAGES_DIR}", file=sys.stderr)
+        return 0
+
+    ok = 0
+    fail = 0
+    for f in files:
+        src = Path(f)
+        dest = map_dest(src)
+        try:
+            public = upload_file(dest, str(src))
+            print(json.dumps({"src": str(src), "dest": dest, "public": public}))
+            ok += 1
+        except Exception as e:  # noqa: BLE001
+            print(json.dumps({"src": str(src), "dest": dest, "error": str(e)}))
+            fail += 1
+    print(f"[upload] done ok={ok} fail={fail}", file=sys.stderr)
+    return 0 if ok > 0 else (1 if fail > 0 else 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/supabase_storage.py
+++ b/scripts/supabase_storage.py
@@ -1,0 +1,50 @@
+import mimetypes
+import os
+from typing import Optional
+
+import requests
+
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SERVICE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+BUCKET = os.getenv("BUCKET", "space-visuals")
+
+
+class SupabaseUploadError(Exception):
+    pass
+
+
+def _public_url(path_key: str) -> str:
+    return f"{SUPABASE_URL}/storage/v1/object/public/{BUCKET}/{path_key.lstrip('/')}"
+
+
+def upload_bytes(
+    path_key: str,
+    data: bytes,
+    content_type: Optional[str] = None,
+    cache_control: str = "public, max-age=300",
+) -> str:
+    if not SUPABASE_URL or not SERVICE_KEY:
+        raise SupabaseUploadError("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+    if not content_type:
+        content_type = mimetypes.guess_type(path_key)[0] or "application/octet-stream"
+    url = f"{SUPABASE_URL}/storage/v1/object/{BUCKET}/{path_key.lstrip('/')}"
+    headers = {
+        "Authorization": f"Bearer {SERVICE_KEY}",
+        "Content-Type": content_type,
+        "x-upsert": "true",
+        "cache-control": cache_control,
+    }
+    resp = requests.post(url, headers=headers, data=data, timeout=60)
+    if not (200 <= resp.status_code < 300):
+        raise SupabaseUploadError(f"Upload failed {resp.status_code}: {resp.text[:200]}")
+    return _public_url(path_key)
+
+
+def upload_file(
+    path_key: str,
+    local_path: str,
+    content_type: Optional[str] = None,
+    cache_control: str = "public, max-age=300",
+) -> str:
+    with open(local_path, "rb") as fh:
+        return upload_bytes(path_key, fh.read(), content_type, cache_control)


### PR DESCRIPTION
## Summary
- add Supabase storage helper for uploading generated space visuals assets
- map ingested media to Supabase keys via new upload script for deterministic latest aliases
- run upload step in space-visuals workflow with required dependencies installed

## Testing
- python -m compileall scripts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2abf674c832abc228a56ab03149e)