### PR TITLE
Add ENLIL visual and standardize storage paths

### DIFF
--- a/.github/workflows/space-visuals.yml
+++ b/.github/workflows/space-visuals.yml
@@ -40,6 +40,77 @@ jobs:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
           python3 scripts/space_visuals_ingest.py
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Build & upload ENLIL animation (mp4 + poster)
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          BUCKET: space-visuals
+          ENLIL_BASE_URL: https://services.swpc.noaa.gov/images/animations/enlil/
+        run: |
+          python3 - <<'PY'
+          import os, re, requests, tempfile, subprocess, mimetypes
+          from urllib.parse import urljoin
+
+          SUPABASE_URL = os.environ["SUPABASE_URL"]
+          SERVICE_KEY  = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+          BUCKET       = os.environ.get("BUCKET","space-visuals")
+          BASE         = os.environ.get("ENLIL_BASE_URL","https://services.swpc.noaa.gov/images/animations/enlil/")
+
+          def upload_bytes(path_key, data, content_type=None):
+              if not content_type:
+                  content_type = mimetypes.guess_type(path_key)[0] or "application/octet-stream"
+              url = f"{SUPABASE_URL}/storage/v1/object/{BUCKET}/{path_key.lstrip('/')}"
+              r = requests.post(url, headers={
+                  "Authorization": f"Bearer {SERVICE_KEY}",
+                  "Content-Type": content_type,
+                  "x-upsert": "true",
+                  "cache-control": "public, max-age=300"
+              }, data=data, timeout=300)
+              r.raise_for_status()
+
+          # Scrape frame list
+          idx = requests.get(BASE, timeout=60); idx.raise_for_status()
+          jpgs = re.findall(r'href="([^"]+\.jpg)"', idx.text, flags=re.IGNORECASE)
+          if not jpgs:
+              print("[ENLIL] no JPG frames found; skipping")
+              raise SystemExit(0)
+
+          # Download last ~30 frames
+          with tempfile.TemporaryDirectory() as td:
+              import os
+              frames = jpgs[-30:]
+              paths = []
+              for i,rel in enumerate(frames):
+                  url = urljoin(BASE, rel)
+                  r = requests.get(url, timeout=60); r.raise_for_status()
+                  fn = os.path.join(td, f"frame_{i:03d}.jpg")
+                  open(fn,"wb").write(r.content)
+                  paths.append(fn)
+
+              # Poster = last frame
+              with open(paths[-1],"rb") as f:
+                  upload_bytes("/nasa/enlil/latest.jpg", f.read(), "image/jpeg")
+
+              # Encode to mp4 (12fps, 1280 wide, faststart)
+              mp4 = os.path.join(td, "enlil_latest.mp4")
+              cmd = [
+                "ffmpeg","-y",
+                "-r","12",
+                "-pattern_type","glob","-i", os.path.join(td,"frame_*.jpg"),
+                "-vf","scale=1280:-2:flags=lanczos",
+                "-movflags","+faststart",
+                "-pix_fmt","yuv420p",
+                mp4
+              ]
+              subprocess.run(cmd, check=True)
+              with open(mp4,"rb") as f:
+                  upload_bytes("/nasa/enlil/latest.mp4", f.read(), "video/mp4")
+
+          print("[ENLIL] uploaded latest.mp4 + latest.jpg")
+          PY
       - name: Upload images to Supabase Storage
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}

--- a/app/routers/space_visuals.py
+++ b/app/routers/space_visuals.py
@@ -203,6 +203,16 @@ async def space_visuals(conn=Depends(get_db)):
             }
         )
 
+    items.append(
+        {
+            "id": "enlil_cme",
+            "title": "ENLIL CME Propagation",
+            "credit": "NOAA/WSA–ENLIL+Cone",
+            "url": "/nasa/enlil/latest.mp4",
+            "meta": {"source": "https://services.swpc.noaa.gov/images/animations/enlil/"},
+        }
+    )
+
     return {
         "ok": True,
         "schema_version": 1,


### PR DESCRIPTION
## Summary
- add ENLIL CME propagation entry to space visuals response
- standardize space visuals upload mapping to new Supabase storage keys while keeping legacy uploads
- extend CI workflow to build and upload ENLIL animation and poster using ffmpeg

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692000b34864832a803973fce54dc5bb)