### PR TITLE
Add space visuals diagnostics and CI smoke checks

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -24,6 +24,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check for legacy visuals origins
+        run: |
+          git grep -nE 'cdn\.jsdelivr|gaiaeyes-media|images/space/' || true
+
       - name: Setup Python
         if: ${{ hashFiles('**/*.py') != '' }}
         uses: actions/setup-python@v5

--- a/.github/workflows/space-visuals.yml
+++ b/.github/workflows/space-visuals.yml
@@ -12,6 +12,9 @@ jobs:
     permissions:
       contents: write
       issues: write
+    env:
+      BACKEND_BASE_URL: ${{ secrets.BACKEND_BASE_URL || vars.BACKEND_BASE_URL || '' }}
+      DEV_BEARER: ${{ secrets.DEV_BEARER || vars.DEV_BEARER || '' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -35,7 +38,7 @@ jobs:
         run: |
           python3 scripts/space_visuals_ingest.py
       - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg jq
 
       - name: Build & upload ENLIL animation (mp4 + poster)
         env:
@@ -114,3 +117,16 @@ jobs:
           OUTPUT_JSON_PATH: ${{ runner.temp }}/media/data/space_live.json
         run: |
           python3 scripts/space_visuals_upload_to_supabase.py
+      - name: Smoke check space visuals API
+        if: env.BACKEND_BASE_URL != '' && env.DEV_BEARER != ''
+        env:
+          BASE_URL: ${{ env.BACKEND_BASE_URL }}
+          BEARER: ${{ env.DEV_BEARER }}
+        run: |
+          set -euo pipefail
+          curl -sS -H "Authorization: Bearer ${BEARER}" "${BASE_URL}/v1/space/visuals/diag" | jq .
+          curl -sS -H "Authorization: Bearer ${BEARER}" "${BASE_URL}/v1/space/visuals" \
+            | jq -e 'select(.cdn_base != null and (.items|length) >= 5) | .cdn_base'
+      - name: Skip smoke check (backend env missing)
+        if: env.BACKEND_BASE_URL == '' || env.DEV_BEARER == ''
+        run: echo "Skipping space visuals smoke check; BACKEND_BASE_URL/DEV_BEARER not configured."

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from .routers import health as health_router, ingest, summary, symptoms, space_visuals
- # Resilient imports for optional/relocated modules
+
+# Resilient imports for optional/relocated modules
 try:
     # Preferred layout: app/api/...
     from .api.middleware import WebhookSigMiddleware  # type: ignore
@@ -24,6 +25,7 @@ except ModuleNotFoundError:
 from .utils.auth import require_auth as ensure_authenticated
 from .db import get_pool, open_pool, close_pool
 from .db.health import ensure_health_monitor_started, stop_health_monitor
+from .routers.space_visuals import _media_base
 
 
 logger = logging.getLogger(__name__)
@@ -37,6 +39,8 @@ app = FastAPI(
     version="0.1.0",
     generate_unique_id_function=custom_generate_unique_id
 )
+
+logging.getLogger("uvicorn").info(f"[visuals] media_base at startup: {_media_base() or 'None'}")
 
 @app.exception_handler(Exception)
 async def _global_exception_handler(request: Request, exc: Exception):

--- a/app/routers/summary.py
+++ b/app/routers/summary.py
@@ -1501,9 +1501,11 @@ async def features_today(
 ):
     """Return the daily features snapshot for the caller, honoring timezone overrides."""
 
-    default_media_base = "https://cdn.jsdelivr.net/gh/GaiaEyesHQ/gaiaeyes-media@main"
+    default_media_base = getenv("GAIA_MEDIA_BASE") or ""
     raw_media_base = getenv("MEDIA_BASE_URL")
-    media_base = (raw_media_base or default_media_base).rstrip("/")
+    media_base = (raw_media_base or default_media_base).rstrip("/") if (
+        raw_media_base or default_media_base
+    ) else ""
 
     tz_param = request.query_params.get("tz", DEFAULT_TIMEZONE)
     tz_name, tzinfo = _normalize_timezone(tz_param)

--- a/tests/test_space_visuals_env.py
+++ b/tests/test_space_visuals_env.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.routers.space_visuals import _media_base
+
+
+def test_prefers_visuals_media_base(monkeypatch):
+    monkeypatch.setenv(
+        "VISUALS_MEDIA_BASE_URL",
+        "https://x.supabase.co/storage/v1/object/public/space-visuals/",
+    )
+    monkeypatch.delenv("MEDIA_BASE_URL", raising=False)
+    monkeypatch.delenv("GAIA_MEDIA_BASE", raising=False)
+    assert _media_base() == "https://x.supabase.co/storage/v1/object/public/space-visuals"
+
+
+def test_falls_back_to_media_base(monkeypatch):
+    monkeypatch.delenv("VISUALS_MEDIA_BASE_URL", raising=False)
+    monkeypatch.setenv("MEDIA_BASE_URL", "https://y.supabase.co/space-visuals/")
+    assert _media_base() == "https://y.supabase.co/space-visuals"
+
+
+def test_falls_back_to_gaia_media_base(monkeypatch):
+    monkeypatch.delenv("VISUALS_MEDIA_BASE_URL", raising=False)
+    monkeypatch.delenv("MEDIA_BASE_URL", raising=False)
+    monkeypatch.setenv("GAIA_MEDIA_BASE", "https://z.supabase.co/space-visuals")
+    assert _media_base() == "https://z.supabase.co/space-visuals"
+
+
+def test_empty_when_none(monkeypatch):
+    monkeypatch.delenv("VISUALS_MEDIA_BASE_URL", raising=False)
+    monkeypatch.delenv("MEDIA_BASE_URL", raising=False)
+    monkeypatch.delenv("GAIA_MEDIA_BASE", raising=False)
+    assert _media_base() == ""


### PR DESCRIPTION
## Summary
- add a visuals environment snapshot helper, diagnostics endpoint, and ensure the space visuals response carries a usable cdn base and baseline items
- log the resolved media base at startup, prefer GAIA_MEDIA_BASE over legacy defaults, and add coverage for media base resolution
- wire CI steps to grep for legacy origins and smoke check the space visuals endpoints after ingestion

## Testing
- pytest tests/test_space_visuals_env.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69223c5ce828832a9493bd72f1309441)