### PR TITLE
Fix WordPress space weather detail KP/confidence retrieval

### DIFF
--- a/docs/codex_changelog.md
+++ b/docs/codex_changelog.md
@@ -2,6 +2,14 @@
 
 Document noteworthy backend/front-end changes implemented via Codex tasks. Keep the newest entries at the top.
 
+## 2025-12-07 — Space Weather detail header tolerance
+
+- Updated the WordPress Space Weather detail shortcode to send tolerant API headers (Accept/User-Agent plus optional bearer and
+  `X-Dev-UserId`), accept any 2xx response, and extract KP/Bz/Solar-wind values from multiple backend shapes with last-24h
+  maxima fallbacks.
+- Normalized outlook confidence extraction across label/text payloads and added a hidden debug comment to verify live KP and
+  confidence values in page source.
+
 ## 2025-12-06 — Space visuals public diagnostics and cache headers
 
 - Allowed `/v1/space/visuals` endpoints (including `/public` and `/diag`) to bypass bearer auth


### PR DESCRIPTION
## Summary
- send robust API headers (Accept/User-Agent plus optional bearer and X-Dev-UserId) and accept any 2xx when fetching space weather JSON
- tolerate flexible backend shapes for KP/Bz/solar-wind and outlook confidence while emitting a hidden debug comment for diagnostics
- record the WordPress space weather detail improvements in the Codex changelog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69251c132908832a9a0b4adfa7349487)