### PR TITLE
Fix GDACS ingest module discovery

### DIFF
--- a/.github/workflows/pulse.yml
+++ b/.github/workflows/pulse.yml
@@ -33,11 +33,13 @@ jobs:
         env:
           MEDIA_DIR: ${{ github.workspace }}/gaiaeyes-media
           OUTPUT_JSON_PATH: ${{ github.workspace }}/gaiaeyes-media/data/quakes_latest.json
+          PYTHONPATH: ${{ github.workspace }}
         run: |
+          set -euo pipefail
           mkdir -p "${MEDIA_DIR}/data"
           python scripts/ingest_usgs_quakes.py
           OUTPUT_JSON_PATH="${MEDIA_DIR}/data/alerts_us_latest.json" python scripts/ingest_alerts_us.py
-          OUTPUT_JSON_PATH="${MEDIA_DIR}/data/gdacs_latest.json"    python scripts/ingest_gdacs.py
+          OUTPUT_JSON_PATH="${MEDIA_DIR}/data/gdacs_latest.json"    python -m scripts.ingest_gdacs
           OUTPUT_JSON_PATH="${MEDIA_DIR}/data/pulse.json" python scripts/pulse_emit.py
 
       - name: Commit & push updates

--- a/docs/codex_changelog.md
+++ b/docs/codex_changelog.md
@@ -2,6 +2,12 @@
 
 Document noteworthy backend/front-end changes implemented via Codex tasks. Keep the newest entries at the top.
 
+## 2025-05-29 — Fix GDACS module imports in CI
+
+- Marked `scripts/` as a package and updated the pulse workflow to run the GDACS ingester
+  via `python -m` with the repository root on `PYTHONPATH`, preventing `ModuleNotFoundError`
+  errors in CI and local runs.
+
 ## 2025-05-28 — Supabase-first rollout, quake feeds, and outlook normalization
 
 - Normalized `/v1/space/forecast/outlook` to emit flattened headline/confidence/impact fields while preserving the richer

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Makes 'scripts' an importable package


### PR DESCRIPTION
## Summary
- add package marker so `scripts` can be imported
- run GDACS ingest as a module in the pulse workflow with PYTHONPATH set
- document the CI import fix in the Codex change log

## Testing
- not run (CI only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692740c1ee34832ab71da4d23c3db0ea)