### PR TITLE
Document GitHub Actions workflow inventory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Gaia Eyes — Agent Operating Guide
+
+This file defines how automation agents (Codex/ChatGPT/etc.) must work in this repo.
+
+## Mandatory workflow
+1. **Read first**: locate and review relevant files + existing docs before editing.
+2. **Plan**: state a short plan when a task is non-trivial.
+3. **Implement minimal diff**: prefer the smallest viable change.
+4. **Run checks**: execute lint/tests/build where feasible.
+5. **Document verification**: report what you ran and why.
+
+## Prohibited behavior
+- No refactors, renames, or rewrites unless explicitly requested.
+- No new libraries/dependencies without approval.
+- No new naming conventions or parallel data sources.
+- No secret material added to docs or configs.
+
+## Required output format (agent responses)
+- Summary of changes.
+- Files changed (list paths).
+- Commands run + results.
+- Verification steps the reviewer can take.
+
+## Conventions to follow
+- Backend API changes must follow patterns in `app/routers` + `app/security`.
+- Supabase schema changes must be migration SQL in `supabase/migrations`.
+- iOS changes must respect SwiftUI/AppState patterns.
+- WordPress changes must stay within mu-plugins or theme overrides already in use.
+
+## When in doubt
+- **Do not guess.** Add a question to `docs/OPEN_QUESTIONS.md` with:
+  - what’s unknown
+  - why it matters
+  - who can answer it / where to fill it in

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -1,0 +1,64 @@
+# Gaia Eyes Project Constitution
+
+This document is enforceable and applies to every change in this repository.
+
+## Components & Languages
+- **Backend**: Python (FastAPI), PostgreSQL (Supabase) — `/app`, `/api`, `/scripts`, `/workers`.
+- **iOS App**: Swift/SwiftUI — `/gaiaeyes-ios/ios`.
+- **WordPress**: PHP (mu-plugins + theme) — `/wp-content`.
+- **Data layer**: Supabase Postgres + Supabase Storage — `/supabase` (migrations, config).
+
+## Directory ownership
+- **Backend API** lives in `/app` and `/api` only.
+- **Schema changes** live in `/supabase/migrations` only.
+- **iOS** changes live in `/gaiaeyes-ios/ios` only.
+- **WordPress** changes live in `/wp-content` only.
+- **Docs** live in `/docs` and root Markdown files only.
+
+## Do / Don’t Rules (non-negotiable)
+**Do**
+- Follow existing API routes and auth patterns.
+- Keep Supabase as the source of truth; add endpoints before adding new JSON pipelines.
+- Document every non-trivial behavior change.
+- Prefer minimal diffs; avoid refactors unless requested.
+
+**Don’t**
+- Don’t invent new naming conventions for tables, env vars, or endpoints.
+- Don’t bypass Supabase auth rules or store secrets in the repo.
+- Don’t add dependencies or new services without explicit approval.
+- Don’t delete existing features unless a task explicitly requires it.
+
+## Patterns to copy (canonical examples)
+- **Auth + user context**: `app/security/auth.py` (bearer + dev headers + Supabase JWT).
+- **DB access**: `app/db/__init__.py` (connection pool + failover + timeouts).
+- **Endpoint structure**: `app/routers/summary.py` (read-only aggregation) and `app/routers/ingest.py` (write ingest).
+- **iOS API usage**: `gaiaeyes-ios/ios/GaiaExporter/Services/APIClient.swift`.
+- **WP API helper**: `wp-content/mu-plugins/gaiaeyes-api-helpers.php`.
+
+## Error handling + logging
+- Backend endpoints return safe JSON envelopes (`{"ok": false, ...}`) on failure.
+- All DB operations should guard with timeouts and log failures; avoid silent exceptions.
+- Client-side code (iOS/WP) should log and fall back without crashing.
+
+## Data access rules
+- Supabase is the **universal truth**.
+- Backend owns writes to Supabase; clients should prefer backend endpoints.
+- JSON files are **legacy fallback** only; create/extend endpoints before adding new JSON.
+
+## Definition of done (per change)
+- Lint/test/build commands for the touched component run (or are documented as not runnable here).
+- Docs updated if behavior, env vars, or endpoints change.
+- No secrets added, no unexplained deletions.
+
+## PR checklist
+- [ ] Updated docs for the change.
+- [ ] Confirmed Supabase schema + RLS impact (if applicable).
+- [ ] Included migration file for DB schema changes.
+- [ ] Ran or documented tests.
+- [ ] Noted any remaining TODOs in `docs/OPEN_QUESTIONS.md`.
+
+## Review checklist
+- [ ] Changes align with existing patterns (no new conventions).
+- [ ] Supabase remains the source of truth.
+- [ ] API/auth compatibility preserved.
+- [ ] WordPress/iOS fallbacks still safe.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to Gaia Eyes
+
+## Local development
+### Backend (FastAPI)
+1. Create a venv and install deps.
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Configure `.env` using `.env.example` (see `docs/ENVIRONMENT_VARIABLES.md`).
+3. Run the API:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+### Supabase (local, optional)
+- See `docs/SUPABASE.md` for `supabase` CLI expectations and schema notes.
+
+### WordPress
+- This repo contains only `wp-content/` (no WP core). Bring your own WordPress install and mount/copy `wp-content` in.
+- Configure env vars for mu-plugins (see `docs/ENVIRONMENT_VARIABLES.md`).
+
+### iOS
+- Build instructions are in `docs/IOS_APP.md` and `gaiaeyes-ios/ios/README_iOS.md`.
+
+## Branching + PRs
+- Create a feature branch per task.
+- Keep diffs minimal and focused.
+- Update docs when behavior or env vars change.
+
+## Linting/tests
+- Backend: run existing tests/lints from `requirements.txt` (see `docs/BACKEND.md`).
+- iOS: use Xcode build/test commands documented in `docs/IOS_APP.md`.
+- WordPress: no automated tests in repo — validate manually.
+
+## Adding features
+### Backend endpoints
+- Add new routes in `app/routers/` and include them in `app/main.py`.
+- Keep auth/authorization consistent with `app/security/auth.py`.
+
+### iOS screens
+- Follow MVVM/ObservableObject pattern in `gaiaeyes-ios/ios/GaiaExporter`.
+
+### WordPress integrations
+- Prefer mu-plugins in `wp-content/mu-plugins` for shortcodes/data access.
+
+## Supabase schema changes
+- Always add a new migration under `supabase/migrations`.
+- Document new tables/columns in `docs/SUPABASE.md` and `docs/ENVIRONMENT_VARIABLES.md`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,94 @@
+# Architecture
+
+## System overview
+```mermaid
+flowchart LR
+  subgraph Clients
+    IOS[iOS App]
+    WP[WordPress wp-content]
+  end
+
+  subgraph Backend
+    API[FastAPI /app]
+    DB[(Supabase Postgres)]
+    Storage[(Supabase Storage)]
+  end
+
+  IOS -->|Bearer + X-Dev-UserId| API
+  WP -->|Bearer + X-Dev-UserId| API
+  API --> DB
+  API --> Storage
+
+  subgraph Legacy
+    Media[gaiaeyes-media JSON CDN]
+  end
+  IOS -->|CDN fallback| Media
+  WP -->|JSON fallback| Media
+```
+
+## Universal truth
+Supabase is the universal data source (Postgres + Auth + Storage). The backend owns writes to Supabase and exposes API endpoints for clients. JSON snapshots (gaiaeyes-media) are legacy fallbacks and are being phased out.
+
+## Data flow: Health samples (iOS → Supabase)
+```mermaid
+sequenceDiagram
+  participant iOS as iOS App
+  participant API as FastAPI /v1/samples/batch
+  participant DB as Supabase Postgres (gaia.samples)
+
+  iOS->>API: POST /v1/samples/batch (HealthKit samples)
+  API->>DB: INSERT rows (gaia.samples)
+  API-->>iOS: ok/inserted/skipped
+```
+
+## Data flow: Space weather + visuals
+```mermaid
+sequenceDiagram
+  participant Bots as Ingest scripts
+  participant DB as Supabase Postgres
+  participant API as FastAPI
+  participant WP as WordPress
+
+  Bots->>DB: ingest ext.* and marts.* tables
+  API->>DB: read /v1/space/* + /v1/space/visuals
+  WP->>API: fetch API endpoints when configured
+  WP-->>Media: fallback to JSON if API unavailable
+```
+
+## Data flow: Symptoms
+```mermaid
+sequenceDiagram
+  participant iOS as iOS App
+  participant API as FastAPI /v1/symptoms
+  participant DB as Supabase Postgres (raw.user_symptom_events)
+
+  iOS->>API: POST /v1/symptoms
+  API->>DB: INSERT raw.user_symptom_events
+  API-->>iOS: ok/id
+  iOS->>API: GET /v1/symptoms/daily
+  API->>DB: read marts.symptom_daily
+```
+
+## Key modules (back-end)
+- **API entry point**: `app/main.py`
+- **Auth**: `app/security/auth.py` + `app/utils/auth.py`
+- **DB pool + failover**: `app/db/__init__.py`
+- **Core routers**: `app/routers/*.py`
+- **Webhook support**: `api/middleware.py`, `api/webhooks.py`
+
+## Key modules (iOS)
+- **App state + MVVM**: `gaiaeyes-ios/ios/GaiaExporter/ViewModels/AppState.swift`
+- **Networking**: `gaiaeyes-ios/ios/GaiaExporter/Services/APIClient.swift`
+- **Background sync**: `gaiaeyes-ios/ios/GaiaExporter/Services/HealthKitBackgroundSync.swift`
+
+## Key modules (WordPress)
+- **API helper**: `wp-content/mu-plugins/gaiaeyes-api-helpers.php`
+- **Space visuals**: `wp-content/mu-plugins/gaiaeyes-space-visuals.php`
+- **Space weather detail**: `wp-content/mu-plugins/gaiaeyes-space-weather-detail.php`
+- **Theme shortcodes**: `wp-content/themes/neve/functions.php`
+
+## Known inconsistencies + TODOs (from current repo)
+- **Schumann latest endpoint vs schema**: `/v1/earth/schumann/latest` reads `marts.daily_features` columns `f0..f5`, but the migration for `marts.daily_features` does not define those columns. This endpoint likely needs a schema alignment or a different source.
+- **Webhook stubs**: `/hooks/*` endpoints are present but include TODOs and do not implement downstream actions yet.
+- **Multiple data sources**: several components still fall back to JSON snapshots (gaiaeyes-media) while backend endpoints also exist. This creates duplicate paths that can drift.
+- **Media base overlap**: multiple env vars (`VISUALS_MEDIA_BASE_URL`, `MEDIA_BASE_URL`, `GAIA_MEDIA_BASE`) can define the same base URL, which can cause confusion.

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -1,0 +1,74 @@
+# Backend (FastAPI)
+
+## Entry point + structure
+- Entry point: `app/main.py` initializes the FastAPI app, middleware, CORS, DB pool, and routers.
+- Routers live in `app/routers/` and are grouped by domain.
+- Database access uses async psycopg connection pooling in `app/db/__init__.py`.
+- Auth helpers live in `app/security/auth.py` and `app/utils/auth.py`.
+
+## Auth strategy
+- **Read tokens**: allowlisted via `READ_TOKENS` env var.
+- **Write tokens**: allowlisted via `WRITE_TOKENS` env var.
+- **Supabase JWT**: validated using `SUPABASE_JWT_SECRET` to extract `user_id`.
+- **Dev override**: `DEV_BEARER` + `X-Dev-UserId` attach a user in dev/test.
+- Certain GET routes can be publicly readable via `PUBLIC_READ_ENABLED` and `PUBLIC_READ_PATHS`.
+
+## API surface (routes)
+### Health + diagnostics
+- `GET /health` (health check)
+- `GET /v1/diag/db` (db diagnostics)
+- `GET /v1/diag/dbpool` (pool diagnostics)
+- `GET /v1/db/ping` (db ping)
+
+### Hazards + badges
+- `GET /gdacs`
+- `GET /brief`
+- `GET /kp_schumann`
+
+### Space + visuals
+- `GET /v1/space/visuals` (space visuals + media list)
+- `GET /v1/space/visuals/public` (public visuals)
+- `GET /v1/space/visuals/diag` (visuals diagnostics)
+- `GET /v1/space/flares`
+- `GET /v1/space/history`
+- `GET /v1/space/xray/history`
+- `GET /v1/space/magnetosphere`
+- `GET /v1/space/forecast/summary`
+- `GET /v1/space/forecast/outlook`
+- `GET /v1/space/series` and `GET /v1/series` (legacy alias)
+
+### Earth + quakes
+- `GET /v1/earth/schumann/latest`
+- `GET /v1/quakes/daily`
+- `GET /v1/quakes/events`
+- `GET /v1/quakes/latest`
+- `GET /v1/quakes/monthly`
+- `GET /v1/quakes/history`
+
+### Features + symptoms
+- `GET /v1/features/today` (daily features snapshot)
+- `POST /v1/symptoms` (log a symptom)
+- `GET /v1/symptoms/today`
+- `GET /v1/symptoms/daily`
+- `GET /v1/symptoms/diag`
+- `GET /v1/symptoms/codes`
+
+### Ingest
+- `POST /samples/batch` (samples batch ingest)
+- `POST /v1/samples/batch` (compat alias)
+
+### Webhooks
+- `POST /hooks/earthscope`
+- `POST /hooks/social`
+
+## Validation strategy
+- Pydantic models are used for request/response validation in routers.
+- The backend returns safe envelopes (`{"ok": false, ...}`) on error to keep clients resilient.
+
+## Supabase access
+- The backend connects directly to Supabase Postgres via `DATABASE_URL` and optional `DIRECT_URL` failover.
+- Storage uploads use `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`.
+
+## Testing
+- `tests/` exists for backend-related tests.
+- No unified test runner is documented; if you add new tests, document the command in this file.

--- a/docs/DEPLOY_RENDER.md
+++ b/docs/DEPLOY_RENDER.md
@@ -1,0 +1,20 @@
+# Render Deployment
+
+## What is hosted on Render
+- **Backend API**: FastAPI (`app.main:app`) built as a web service.
+- **Cron jobs / workers**: not defined in repo, but implied by scripts/ and workers/ (see `docs/OPEN_QUESTIONS.md`).
+
+## Build + start commands (in repo)
+- **Dockerfile** builds a Python 3.11 image and runs `uvicorn app.main:app --host 0.0.0.0 --port 8080`.
+- **Procfile** defines `web: uvicorn app:app --host 0.0.0.0 --port=${PORT:-8000}` for non-Docker deployments.
+- **runtime.txt** specifies `python-3.11.9`.
+
+## Deploy pipeline
+- There is no `render.yaml` in the repo, so the Render dashboard likely defines services, env vars, and cron schedules manually.
+- Most scheduled ingestion and publishing runs via GitHub Actions workflows; see `docs/GITHUB_ACTIONS.md`.
+
+## Environment variables
+See `docs/ENVIRONMENT_VARIABLES.md` for required env vars (DATABASE_URL, SUPABASE_JWT_SECRET, etc).
+
+## Missing Render details
+See `docs/OPEN_QUESTIONS.md` for gaps that must be confirmed in the Render dashboard (service names, build settings, cron jobs, etc.).

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1,0 +1,57 @@
+# Environment Variables
+
+> **Do not commit real secrets.** Use placeholders and rotate any leaked tokens.
+
+## Backend (FastAPI)
+| Variable | Purpose | Example placeholder | Where used |
+| --- | --- | --- | --- |
+| `DATABASE_URL` | Supabase Postgres connection | `postgresql://postgres:***@db.<project>.supabase.co:5432/postgres` | `app/db/__init__.py` |
+| `DIRECT_URL` | Optional direct Postgres fallback | `postgresql://postgres:***@db.<project>.supabase.co:5432/postgres` | `app/db/__init__.py` |
+| `SUPABASE_JWT_SECRET` | Validate Supabase JWTs | `supabase-jwt-secret` | `app/utils/auth.py` |
+| `SUPABASE_URL` | Supabase REST/Storage base URL | `https://<project>.supabase.co` | `app/utils/supabase_storage.py` |
+| `SUPABASE_SERVICE_ROLE_KEY` | Storage uploads | `service-role-key` | `app/utils/supabase_storage.py` |
+| `BUCKET` | Storage bucket name | `space-visuals` | `app/utils/supabase_storage.py` |
+| `READ_TOKENS` | Comma-separated read tokens | `token1,token2` | `app/security/auth.py` |
+| `WRITE_TOKENS` | Comma-separated write tokens | `token1,token2` | `app/security/auth.py` |
+| `DEV_BEARER` | Dev bearer token | `devtoken123` | `app/security/auth.py`, `app/db/__init__.py` |
+| `PUBLIC_READ_ENABLED` | Enable public read allowlist | `1` | `app/security/auth.py` |
+| `PUBLIC_READ_PATHS` | CSV allowlist of public GET paths | `/health,/v1/space/visuals` | `app/security/auth.py` |
+| `CORS_ORIGINS` | CORS origin list | `*` | `app/db/__init__.py` |
+| `REDIS_URL` | Optional caching/queues | `redis://...` | `app/db/__init__.py` |
+| `FEATURES_CACHE_TTL_SECONDS` | Features cache TTL | `300` | `app/db/__init__.py` |
+| `MEDIA_BASE_URL` | Default CDN base for visuals | `https://.../gaiaeyes-media` | `app/routers/summary.py` |
+| `GAIA_MEDIA_BASE` | Alternate CDN base | `https://.../gaiaeyes-media` | `app/routers/summary.py` |
+| `VISUALS_MEDIA_BASE_URL` | Visuals-specific CDN base | `https://.../gaiaeyes-media` | `app/routers/space_visuals.py` |
+| `GOES_XRS_URL` | Space flares data source | `https://services.swpc.noaa.gov/...` | `app/routers/space.py` |
+| `MART_REFRESH_DISABLE` | Disable mart refresh on ingest | `0` | `app/routers/ingest.py` |
+| `DEBUG_FEATURES_DIAG` | Enable features diagnostics | `1` | `app/routers/summary.py` |
+| `WEBHOOK_SECRET` | HMAC secret for `/hooks/*` | `webhook-secret` | `api/middleware.py`, `api/webhooks.py` |
+
+## iOS (runtime/in-app)
+| Variable | Purpose | Where set |
+| --- | --- | --- |
+| `API Base URL` | Backend base URL | In-app settings (stored in `UserDefaults`) |
+| `Bearer Token` | Backend bearer token | In-app settings |
+| `User UUID` | Supabase user id | In-app settings |
+| `MEDIA_BASE_URL` | CDN fallback base URL | Process env (if set) |
+
+## WordPress (wp-content)
+| Variable | Purpose | Example placeholder | Where used |
+| --- | --- | --- | --- |
+| `GAIAEYES_API_BASE` | Backend API base URL | `https://gaiaeyes-backend.onrender.com` | `wp-content/mu-plugins/gaiaeyes-space-weather-detail.php` |
+| `GAIAEYES_API_BEARER` | Backend bearer token | `devtoken123` | `wp-content/mu-plugins/gaiaeyes-space-weather-detail.php` |
+| `GAIAEYES_API_DEV_USERID` | Dev user id for backend | `uuid` | `wp-content/mu-plugins/gaiaeyes-space-weather-detail.php` |
+| `GAIAEYES_SPACE_VISUALS_ENDPOINT` | Override space visuals API URL | `https://.../v1/space/visuals` | `wp-content/mu-plugins/gaiaeyes-space-visuals.php` |
+| `GAIAEYES_SPACE_VISUALS_BEARER` | Auth for space visuals endpoint | `token` | `wp-content/mu-plugins/gaiaeyes-space-visuals.php` |
+| `GAIA_MEDIA_BASE` | Base URL for JSON/media | `https://.../gaiaeyes-media` | `wp-content/mu-plugins/gaiaeyes-space-visuals.php` |
+| `GAIA_AURORA_NOWCAST_URL` | Aurora nowcast URL override | `https://services.swpc.noaa.gov/...` | `wp-content/mu-plugins/gaia-aurora.php` |
+| `GAIA_AURORA_IMAGE_NORTH` | Aurora image override (north) | `https://.../north.png` | `wp-content/mu-plugins/gaia-aurora.php` |
+| `GAIA_AURORA_IMAGE_SOUTH` | Aurora image override (south) | `https://.../south.png` | `wp-content/mu-plugins/gaia-aurora.php` |
+| `GAIA_AURORA_CACHE_TTL_SECONDS` | Cache TTL | `600` | `wp-content/mu-plugins/gaia-aurora.php` |
+| `GAIA_AURORA_VIEWLINE_P` | Viewline probability | `50` | `wp-content/mu-plugins/gaia-aurora.php` |
+| `GAIA_AURORA_VIEWLINE_P_NORTH` | Viewline probability north | `50` | `wp-content/mu-plugins/gaia-aurora.php` |
+| `GAIA_AURORA_SMOOTH_WINDOW` | Smoothing window | `5` | `wp-content/mu-plugins/gaia-aurora.php` |
+| `GAIA_AURORA_ENABLE_JSON_EXPORT` | Enable JSON export | `0` | `wp-content/mu-plugins/gaia-aurora.php` |
+
+## Render
+Render-specific env vars are likely set in the dashboard (see `docs/OPEN_QUESTIONS.md`).

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -1,0 +1,51 @@
+# GitHub Actions
+
+This repo relies heavily on GitHub Actions for scheduled ingestion, JSON snapshot generation, and WordPress publishing. Render is used for hosting the backend, but most recurring jobs run here.
+
+## Where to look
+- Workflows live in `.github/workflows/`.
+- The audit helper is `docs/github-actions-audit.md` + `scripts/audit_workflows.py`.
+
+## Workflow inventory (by file)
+> **Note:** Cron schedules are defined inside each workflow file. Update schedules there.
+
+### Space + earth data ingest
+- `space-weather.yml` — ingest space weather + JSON export.
+- `space-weather-daily-rollup.yml` — daily rollup of space weather marts.
+- `ingest_space_forecasts.yml` — Step 1 space forecast ingestion.
+- `space-visuals.yml` — space visuals ingest + storage upload.
+- `magnetosphere.yml` — magnetosphere KPIs + JSON/media updates.
+- `schumann-ingest.yml` — ingest Schumann data (in repo).
+- `schumann.yml` — Schumann processing pipeline.
+- `quakes_ingest.yml` — ingest quake data.
+- `quakes-history.yml` — build quake history JSON.
+- `quakes-backfill.yml` — quake backfill.
+- `compare-series.yml` — build compare_series + space history JSON.
+- `earthscope-rules.yml` — build earthscope rules JSON.
+- `earthscope_post.yml` — Earthscope daily post bot.
+- `aurora_fetch.yml` — aurora fetch/nowcast cron.
+- `volcanoes-ingest.yml` — weekly volcano ingestion.
+
+### Health + features rollups
+- `health-daily-rollup.yml` — daily health rollups.
+- `daily-features-rollup.yml` — rolling daily features refresh.
+
+### Content + social
+- `gaia_eyes_daily.yml` — daily Earthscope pipeline (Supabase + media JSON).
+- `space_news.yml` — space news pipeline + WP publish.
+- `news-ingest.yml` — news JSON ingest.
+- `research_lane.yml` — research collection lane.
+- `research_watch.yml` — research watch pipeline.
+- `social.yml` — social fact render + post.
+- `wp_post.yml` — WordPress daily publish.
+- `wp-deploy.yml` — deploy `wp-content` to SiteGround.
+
+### Site maintenance + linting
+- `lint-links.yml` — ensure legacy owner links don’t appear.
+- `workflow-yamllint.yml` — lint workflow YAML.
+- `site-assets-check.yml` — validate external assets listed in docs.
+- `review.yml` — PR review automation.
+- `pulse.yml` — pulse JSON output.
+
+## Open questions
+See `docs/OPEN_QUESTIONS.md` for missing Render cron details; however, most scheduled work lives in these GitHub Actions workflows.

--- a/docs/IOS_APP.md
+++ b/docs/IOS_APP.md
@@ -1,0 +1,34 @@
+# iOS App (GaiaExporter)
+
+## Location
+- Source lives in `gaiaeyes-ios/ios/GaiaExporter`.
+
+## Build/run
+- See `gaiaeyes-ios/ios/README_iOS.md` for step-by-step setup, HealthKit entitlements, and local run instructions.
+
+## Architecture
+- SwiftUI app with an `AppState` ObservableObject shared across views.
+- Background tasks are registered on app launch for HealthKit sync and processing.
+
+## Networking layer
+- `APIClient` handles GET/POST requests with retries, tolerance for JSON decoding, and optional CDN fallback.
+- Uses `Authorization: Bearer <token>` plus `X-Dev-UserId` when available to align with backend auth.
+
+## Auth + user identity
+- Dev defaults (base URL, bearer token, user UUID) are stored in `AppState` and persisted to `UserDefaults`.
+- Tokens are attached to requests as standard bearer auth.
+
+## Environment/config
+- API base URL and dev tokens are configured in-app via the connection settings UI.
+- `MEDIA_BASE_URL` env var (optional) enables CDN fallback to JSON snapshots when the backend is unavailable.
+
+## Dependencies (SwiftPM)
+- Polar BLE SDK (6.10.0)
+- RxSwift (6.5.0)
+- SwiftProtobuf (1.33.3)
+- Zip (2.1.2)
+
+## Backend endpoints used by the app
+- `/v1/samples/batch` for HealthKit uploads.
+- `/v1/symptoms` and related symptom list endpoints.
+- `/v1/features/today`, `/v1/space/forecast/*`, `/v1/space/series`, `/v1/space/visuals` (with CDN fallbacks).

--- a/docs/NEW_AGENT_GUIDE.md
+++ b/docs/NEW_AGENT_GUIDE.md
@@ -1,0 +1,68 @@
+# New Agent Guide (Single-Doc Canonical)
+
+This document is the one-stop reference for new agents working in this repo. It summarizes the architecture, conventions, and safe workflows so changes do not introduce naming drift or delete useful code.
+
+## 1) What you are working on
+Gaia Eyes combines a FastAPI backend, a Swift iOS app, and a WordPress front-end. Supabase (Postgres + Auth + Storage) is the universal source of truth. JSON snapshots from `gaiaeyes-media` still exist as legacy fallbacks and are being phased out in favor of Supabase-backed endpoints.
+
+## 2) Component map (where to change what)
+- **Backend API**: `/app` and `/api`
+- **Supabase schema**: `/supabase/migrations`
+- **iOS app**: `/gaiaeyes-ios/ios`
+- **WordPress (site)**: `/wp-content`
+- **Docs**: `/docs` and root Markdown files
+
+## 3) Hard rules (do not violate)
+- Do **not** change naming conventions for tables, routes, env vars, or data keys.
+- Do **not** add new JSON pipelines; prefer Supabase + backend endpoints.
+- Do **not** refactor unrelated code or delete features without explicit request.
+- Do **not** commit secrets. Use placeholders and add a rotation note if you find real secrets.
+
+## 4) Auth & data access conventions
+**Backend auth**
+- Read endpoints can be allowlisted (`PUBLIC_READ_ENABLED`, `PUBLIC_READ_PATHS`) but otherwise require bearer auth.
+- Write endpoints require bearer auth; tokens can be either pre-shared (`READ_TOKENS`, `WRITE_TOKENS`) or Supabase JWTs.
+- Dev flows use `DEV_BEARER` plus `X-Dev-UserId`.
+
+**Supabase access**
+- Backend writes directly to Supabase. Clients should prefer backend endpoints, not direct DB access.
+- Storage uploads use `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`.
+
+## 5) API routing conventions (backend)
+Backend routes are grouped by domain under `app/routers/` and registered in `app/main.py`.
+- Space/visuals: `/v1/space/*` and `/v1/space/visuals`
+- Quakes: `/v1/quakes/*`
+- Earth/Schumann: `/v1/earth/schumann/latest`
+- Features: `/v1/features/today`
+- Symptoms: `/v1/symptoms/*`
+- Ingest: `/v1/samples/batch`
+
+Do not add routes in random files. Keep them in `app/routers/*` and include them in `app/main.py`.
+
+## 6) iOS conventions
+- `AppState` is the central ObservableObject.
+- `APIClient` handles retries, tolerant decoding, and CDN fallback.
+- The app expects `Authorization: Bearer <token>` + optional `X-Dev-UserId`.
+
+## 7) WordPress conventions
+- Use mu-plugins for data shortcodes and API calls.
+- Use `gaiaeyes-api-helpers.php` for API fetch + caching.
+- Prefer backend API where available; fallback to JSON is legacy-only.
+
+## 8) Known inconsistencies to avoid worsening
+- `/v1/earth/schumann/latest` reads columns (`f0..f5`) that are not defined in `marts.daily_features` migration.
+- `/hooks/*` endpoints are placeholders with TODOs only.
+- Multiple media base env vars (`VISUALS_MEDIA_BASE_URL`, `MEDIA_BASE_URL`, `GAIA_MEDIA_BASE`) can conflict; keep them aligned.
+
+## 9) Required workflow for every task
+1. Read relevant files + docs.
+2. Propose a short plan.
+3. Implement the **smallest** viable diff.
+4. Run or document checks (tests/builds).
+5. Update docs for any changes to routes, env vars, data formats.
+
+## 10) When you are unsure
+Add a question to `docs/OPEN_QUESTIONS.md` instead of guessing. Include:
+- What is unknown
+- Why it matters
+- Where a human can confirm it

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -1,0 +1,25 @@
+# Open Questions
+
+1. **Render services + cron jobs**
+   - **Why needed**: backend + scheduled ingest jobs are not defined in repo (`render.yaml` missing).
+   - **Where to fill**: Render dashboard (service list, cron schedules, env vars).
+
+2. **Supabase dashboard-only settings**
+   - **Why needed**: RLS policies beyond migrations, storage bucket ACLs, and auth settings may exist only in the dashboard.
+   - **Where to fill**: Supabase dashboard → Auth / Storage / Database policies.
+
+3. **JSON pipelines still required**
+   - **Why needed**: WordPress and iOS still rely on gaiaeyes-media JSON fallbacks; it’s unclear which pipelines are still scheduled and which are deprecated.
+   - **Where to fill**: Ops runbooks or Render/cron job configs.
+
+4. **Space visuals media hosting**
+   - **Why needed**: Visuals can be served from Supabase storage or legacy CDN; the current authoritative source isn’t explicit.
+   - **Where to fill**: Backend env vars (`VISUALS_MEDIA_BASE_URL`, `MEDIA_BASE_URL`, `GAIA_MEDIA_BASE`) and storage bucket configuration.
+
+5. **Backend webhook consumers**
+   - **Why needed**: `/hooks/*` endpoints are stubs with TODOs and may need downstream integrations.
+   - **Where to fill**: Product/ops decision on desired webhook side effects.
+
+6. **Schumann latest endpoint source**
+   - **Why needed**: `/v1/earth/schumann/latest` reads `marts.daily_features` columns (`f0..f5`) that are not present in the migration schema.
+   - **Where to fill**: Confirm intended data source (marts.schumann_daily vs daily_features) and update schema or endpoint accordingly.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# Gaia Eyes Docs Index
+
+## Core docs (new canonical set)
+- `ARCHITECTURE.md` — system overview + data flows
+- `SUPABASE.md` — schema + auth + storage
+- `DEPLOY_RENDER.md` — Render hosting/deploy notes
+- `BACKEND.md` — FastAPI entry points + routes
+- `IOS_APP.md` — Swift app build + networking
+- `WORDPRESS.md` — wp-content overview + data sources
+- `ENVIRONMENT_VARIABLES.md` — env var catalog
+- `TROUBLESHOOTING.md` — common failures + fixes
+- `OPEN_QUESTIONS.md` — missing info that must be filled in manually
+- `NEW_AGENT_GUIDE.md` — one-stop guide for new contributors/agents
+- `GITHUB_ACTIONS.md` — workflow inventory + cron notes
+
+## Existing docs (legacy / supplemental)
+- `app-overview.md`
+- `symptoms_api.md`
+- `MART_REFRESH.md`
+- `SCRIPTS_GUIDE.md`
+- `web/SITE_OVERVIEW.md`
+- `supabase_schema.md`

--- a/docs/SUPABASE.md
+++ b/docs/SUPABASE.md
@@ -1,0 +1,55 @@
+# Supabase
+
+## What lives in Supabase
+- **Postgres schemas**: `gaia`, `raw`, `dim`, `ext`, `marts`.
+- **Auth**: Supabase JWTs validated in backend (see `SUPABASE_JWT_SECRET`).
+- **Storage**: Used for media assets (space visuals), via `SUPABASE_SERVICE_ROLE_KEY` and bucket name.
+
+## Schema management
+- Schema changes live in `supabase/migrations/*.sql` and are expected to be applied via Supabase migrations.
+- Supabase local config is at `supabase/config.toml`.
+
+## RLS overview
+- `gaia` tables are protected with RLS and `auth.uid()` checks (e.g., `gaia.samples`, `gaia.daily_summary`).
+- Symptoms domain uses RLS on `raw.user_symptom_events` (insert/select/delete require `auth.uid() = user_id`).
+
+## Required env vars
+- `DATABASE_URL` (backend DB connection string)
+- `DIRECT_URL` (optional direct Postgres fallback)
+- `SUPABASE_JWT_SECRET` (backend JWT verification)
+- `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (storage uploads)
+
+## Local dev
+- This repo includes `supabase/config.toml` for local Supabase CLI usage.
+- If you use the Supabase CLI, run migrations from `supabase/migrations` to build the local schema.
+
+## Schema summary (from migrations)
+### `gaia` schema
+- `gaia.users` — user records (uuid + email)
+- `gaia.devices` — registered devices per user
+- `gaia.samples` — raw sensor samples (HealthKit/BLE)
+- `gaia.sessions` — session summaries (e.g., BLE)
+- `gaia.daily_summary` — aggregated daily health metrics per user
+
+### `dim` + `raw` schemas (symptoms)
+- `dim.symptom_codes` — allowed symptom codes used by the client
+- `raw.user_symptom_events` — user symptom event log (with RLS)
+
+### `ext` + `marts` schemas (space/earth)
+- `ext.magnetosphere_pulse` — magnetosphere time-series feed
+- `marts.magnetosphere_last_24h` — view for last 24h magnetosphere data
+- `marts.daily_features` — per-user daily features (health + space)
+- `marts.schumann_daily` — Schumann daily aggregated series
+- `marts.symptom_daily`, `marts.symptom_x_space_daily` — materialized views for symptom analytics
+- `ext.enlil_forecast` + `marts.cme_arrivals` — CME simulation and arrivals
+- `ext.sep_flux` — SEP proton flux
+- `ext.radiation_belts` + `marts.radiation_belts_daily` — radiation belt metrics
+- `ext.aurora_power` + `marts.aurora_outlook` — aurora/hemispheric power outlook
+- `ext.ch_forecast` — coronal hole forecasts
+- `ext.cme_scoreboard` — CME arrival scoreboard
+- `ext.drap_absorption` + `marts.drap_absorption_daily` — D-RAP absorption (lat/lon grid extension)
+- `ext.solar_cycle_forecast` + `marts.solar_cycle_progress` — solar cycle forecast summaries
+- `ext.magnetometer_chain` + `marts.magnetometer_regional` — magnetometer chain rollups
+
+## Storage buckets
+- Bucket name defaults to `space-visuals` for visual assets and JSON payloads.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,60 @@
+# Troubleshooting
+
+## Backend auth errors (401)
+**Symptoms**: `Missing or invalid Authorization header` or `Invalid bearer token`.
+**Fixes**:
+- Ensure `Authorization: Bearer <token>` is set.
+- For dev flows, set `DEV_BEARER` and pass `X-Dev-UserId`.
+- For Supabase JWTs, ensure `SUPABASE_JWT_SECRET` is configured.
+
+## Supabase connection failures
+**Symptoms**: API responds with `db_unavailable` or pool timeouts.
+**Fixes**:
+- Verify `DATABASE_URL` and optional `DIRECT_URL`.
+- Check `/v1/db/ping` for connectivity.
+- Inspect pool logs; failover should switch to `DIRECT_URL` if configured.
+
+## Symptom endpoints failing
+**Symptoms**: `unknown symptom_code` or invalid event inserts.
+**Fixes**:
+- Confirm symptom code list in `dim.symptom_codes`.
+- Refresh marts via `scripts/refresh_symptom_marts.py` if daily views are stale.
+
+## CORS issues
+**Symptoms**: browser errors for blocked requests.
+**Fixes**:
+- Confirm `CORS_ORIGINS` is set appropriately.
+- The backend uses permissive `allow_origins=["*"]` by default; validate if a proxy is overriding.
+
+## Space visuals missing
+**Symptoms**: /v1/space/visuals returns empty or missing assets.
+**Fixes**:
+- Confirm `VISUALS_MEDIA_BASE_URL`, `MEDIA_BASE_URL`, or `GAIA_MEDIA_BASE` is configured.
+- Verify uploads to Supabase Storage (bucket `space-visuals`).
+
+## WordPress API fallback only
+**Symptoms**: WP uses JSON and ignores API.
+**Fixes**:
+- Ensure `GAIAEYES_API_BASE` and `GAIAEYES_API_BEARER` are present in the WP environment.
+- Confirm `gaiaeyes-api-helpers.php` is loaded (mu-plugins).
+
+## Render deploy failures
+**Symptoms**: Render build fails or service doesn’t start.
+**Fixes**:
+- Confirm `Dockerfile` and/or `Procfile` matches the service type in Render.
+- Check `runtime.txt` for Python version alignment.
+- Verify required env vars are set in Render.
+
+## iOS build issues
+**Symptoms**: HealthKit or BLE build failures.
+**Fixes**:
+- Build on a real device for HealthKit.
+- Reset SwiftPM caches if dependencies fail to resolve.
+- Ensure HealthKit entitlements are present in the Xcode project.
+
+## WordPress plugin/theme conflicts
+**Symptoms**: Shortcodes not rendering.
+**Fixes**:
+- Confirm mu-plugins are loaded (must-use plugins are always active).
+- Validate shortcodes are present in the active theme or content.
+

--- a/docs/WORDPRESS.md
+++ b/docs/WORDPRESS.md
@@ -1,0 +1,45 @@
+# WordPress (wp-content)
+
+## Structure
+- `wp-content/mu-plugins/` contains most Gaia Eyes data-fetching shortcodes and UI blocks.
+- `wp-content/themes/neve/` includes theme overrides and additional shortcodes.
+
+## Data access strategy
+- Primary mode: fetch backend APIs when `GAIAEYES_API_BASE` is configured.
+- Fallback mode: fetch JSON snapshots from `gaiaeyes-media` (GitHub Pages/jsDelivr) or NOAA endpoints.
+
+## Key mu-plugins + shortcodes
+- **Space visuals** (`gaiaeyes-space-visuals.php`): uses backend API when configured, else `space_live.json`.
+- **Space weather detail** (`gaiaeyes-space-weather-detail.php`): API-first (features + forecast + history + flares), falls back to `space_weather.json` + `flares_cmes.json`.
+- **Magnetosphere card** (`gaiaeyes-magnetosphere.php`): API-first (`/v1/space/magnetosphere`), fallback `magnetosphere_latest.json`.
+- **Schumann detail** (`gaiaeyes-schumann-detail.php`): JSON-only (`schumann_latest.json`, `schumann_combined.json`).
+- **Quakes detail** (`gaiaeyes-earthquake-detail.php`): API-first (`/v1/quakes/*`).
+- **News** (`gaiaeyes-news.php`): JSON-only (`news_latest.json`).
+- **Compare detail** (`gaiaeyes-compare-detail.php`): JSON-only (`compare_series.json`, `quakes_history.json`, `space_history.json`).
+
+## Theme shortcodes (Neve)
+- `gaia_space_weather_bar`: JSON + API fallback (space weather + flares).
+- `gaia_earthscope_banner`: JSON-only (`earthscope_daily.json`, `earthscope.json`).
+- `gaia_pulse` + `gaia_pulse_detail`: JSON-only (`pulse.json`).
+- `gaia_alert_banner`: JSON-only (`space_weather.json`, `quakes_latest.json`).
+
+## JSON datasets still in use (and endpoint parity)
+| JSON dataset | Used in WP | Backend endpoint exists? | Notes |
+| --- | --- | --- | --- |
+| `space_live.json` | Space visuals | **Yes** (`/v1/space/visuals`) | API preferred; JSON fallback remains. |
+| `space_weather.json` | Space weather bar/detail, alert banner | **Partial** | API uses `/v1/space/forecast/*` + `/v1/space/history` + `/v1/features/today`; no 1:1 replacement. |
+| `flares_cmes.json` | Space weather bar/detail | **Partial** | `/v1/space/flares` + forecast outlook; no direct CMEs JSON equivalent. |
+| `magnetosphere_latest.json` | Magnetosphere card | **Yes** (`/v1/space/magnetosphere`) | API preferred. |
+| `schumann_latest.json` | Schumann detail | **Partial** | `/v1/earth/schumann/latest` exists but shape differs. |
+| `schumann_combined.json` | Schumann detail | **No** | Combined dataset only exists as JSON. |
+| `quakes_latest.json` | Alert banner | **Yes** (`/v1/quakes/latest`) | Banner still uses JSON. |
+| `quakes_history.json` | Compare detail | **Yes** (`/v1/quakes/history`) | Compare still uses JSON. |
+| `space_history.json` | Compare detail | **Partial** | `/v1/space/history` exists; compare dataset still JSON. |
+| `compare_series.json` | Compare detail | **No** | JSON-only. |
+| `earthscope_daily.json` | Earthscope banner | **No** | JSON-only. |
+| `earthscope.json` | Earthscope banner | **No** | JSON-only. |
+| `pulse.json` | Pulse cards | **No** | JSON-only. |
+| `news_latest.json` | News | **No** | JSON-only. |
+
+## Environment variables (WP)
+See `docs/ENVIRONMENT_VARIABLES.md` for required env vars like `GAIAEYES_API_BASE`, `GAIAEYES_API_BEARER`, `GAIA_MEDIA_BASE`, and space visuals overrides.

--- a/wp-content/.env.example
+++ b/wp-content/.env.example
@@ -1,0 +1,15 @@
+# WordPress environment variables (mu-plugins)
+GAIAEYES_API_BASE=https://gaiaeyes-backend.onrender.com
+GAIAEYES_API_BEARER=your_bearer_token
+GAIAEYES_API_DEV_USERID=00000000-0000-0000-0000-000000000000
+GAIAEYES_SPACE_VISUALS_ENDPOINT=https://gaiaeyes-backend.onrender.com/v1/space/visuals
+GAIAEYES_SPACE_VISUALS_BEARER=your_visuals_bearer
+GAIA_MEDIA_BASE=https://gaiaeyeshq.github.io/gaiaeyes-media
+GAIA_AURORA_NOWCAST_URL=https://services.swpc.noaa.gov/json/ovation_aurora_latest.json
+GAIA_AURORA_IMAGE_NORTH=
+GAIA_AURORA_IMAGE_SOUTH=
+GAIA_AURORA_CACHE_TTL_SECONDS=600
+GAIA_AURORA_VIEWLINE_P=50
+GAIA_AURORA_VIEWLINE_P_NORTH=50
+GAIA_AURORA_SMOOTH_WINDOW=5
+GAIA_AURORA_ENABLE_JSON_EXPORT=0


### PR DESCRIPTION
### Motivation
- Capture and document the repo's scheduled workflows so maintainers know where cron jobs live and to clarify that most recurring ingestion/publishing runs in GitHub Actions rather than Render.

### Description
- Add `docs/GITHUB_ACTIONS.md` containing an inventory of `.github/workflows/` files and categorize scheduled jobs, and update `docs/README.md` and `docs/DEPLOY_RENDER.md` to link to the new workflow inventory and note that most scheduled work runs via GitHub Actions.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968407c2c2c832a8405aab99072c897)