### PR TITLE
Upgrade Earthscope writer outlook inputs and style rules

### DIFF
--- a/.github/workflows/gaia_eyes_daily.yml
+++ b/.github/workflows/gaia_eyes_daily.yml
@@ -51,6 +51,14 @@ jobs:
       AURORA_REGION: "mid"
       EARTHSCOPE_OUTPUT_JSON_PATH: ${{ github.workspace }}/gaiaeyes-media/data/earthscope_daily.json
       EARTHSCOPE_PULSE_JSON: ${{ github.workspace }}/gaiaeyes-media/data/pulse.json
+      GAIA_BACKEND_BASE: "https://gaiaeyes-backend.onrender.com"
+      STYLE_RULES_PATH: "bots/earthscope_post/style_rules.json"
+      SYMPTOM_GUIDES_PATH: "bots/earthscope_post/symptom_guides.json"
+      WRITER_LENS: "scientific"
+      WRITER_HUMOR: "light"
+      WRITER_TEMP: "0.7"
+      FORCE_PRESSURE_NOTE: "0"
+      OPENAI_WRITER_MODEL: "gpt-5-mini"
     steps:
       - uses: actions/checkout@v4
       - name: Clone media repo (for JSON emit)

--- a/bots/earthscope_post/README.md
+++ b/bots/earthscope_post/README.md
@@ -46,6 +46,7 @@ Plan observability by deciding how to monitor worker runs and webhook deliveries
 The Earthscope Post Bot generates and upserts the daily Earthscope posts consumed by the Gaia Eyes app.
 
 - Reads `marts.space_weather_daily` (+ optional `ext.donki_event`)
+- Pulls consolidated space-weather context from `/v1/space/forecast/outlook` when available
 - Fetches 2–3 trending references (SolarHam, SpaceWeather, NASA, HeartMath)
 - Calls OpenAI to generate rich Daily Earthscope (sections + hashtags)
 - Upserts into `content.daily_posts` (idempotent)
@@ -60,6 +61,10 @@ These posts feed the app’s Earthscope card through the `/v1/features/today` en
 - `PLATFORM` (default `instagram`)
 - `USER_ID` (optional UUID; empty = global)
 - (optional) `TREND_*` URLs to override default sources
+- `GAIA_BACKEND_BASE` (outlook API base, default `https://gaiaeyes-backend.onrender.com`)
+- `STYLE_RULES_PATH` / `SYMPTOM_GUIDES_PATH` (writer style + correlation guides)
+- `WRITER_LENS` (scientific|mystical), `WRITER_HUMOR` (none|light|medium|high)
+- `WRITER_TEMP`, `FORCE_PRESSURE_NOTE`, `OPENAI_WRITER_MODEL`
 
 ### CLI helpers
 - `python bots/earthscope_post/gaia_eyes_viral_bot.py --mode stats --dry-run --kp 4 --bz -6.8 --sw 650 --outdir ./out`

--- a/bots/earthscope_post/prompt_templates.py
+++ b/bots/earthscope_post/prompt_templates.py
@@ -1,0 +1,43 @@
+from typing import Dict, List
+
+SYSTEM_TEMPLATE = """You are Gaia Eyes, a friendly, plain-language space-weather guide.
+Write concise, human, helpful updates. Avoid medical claims. Keep it inclusive.
+Never use the word "textured". Prefer concrete verbs and everyday words.
+Tone: {tone} (humor={humor_level}). Mode: {lens_mode}.
+"""
+
+
+def build_messages(
+    data: Dict,
+    guides: Dict,
+    style: Dict,
+    lens_mode: str = "scientific",
+    humor: str = "light",
+) -> List[Dict]:
+    humor_rules = style.get("humor_guidelines", {}).get(humor, {"spice": 0, "rules": []})
+    return [
+        {
+            "role": "system",
+            "content": SYSTEM_TEMPLATE.format(
+                tone="warm, grounded, optimistic",
+                humor_level=humor,
+                lens_mode=lens_mode,
+            ),
+        },
+        {
+            "role": "user",
+            "content": {
+                "type": "json_schema",
+                "json": {
+                    "data": data,
+                    "style": {
+                        "humor": humor,
+                        "humor_rules": humor_rules,
+                        "softeners": style.get("softener_synonyms", {}),
+                        "banned": style.get("banned_terms", []),
+                    },
+                    "guides": guides,
+                },
+            },
+        },
+    ]

--- a/bots/earthscope_post/style_rules.json
+++ b/bots/earthscope_post/style_rules.json
@@ -1,0 +1,15 @@
+{
+  "banned_terms": [
+    { "find": "textured", "replace_with": ["dynamic", "mixed", "varied", "changeable"] }
+  ],
+  "softener_synonyms": {
+    "may_feel": ["may feel", "could feel", "some people notice", "you might notice"],
+    "tips_lead": ["Try", "Consider", "A gentle nudge", "Quick reset"]
+  },
+  "humor_guidelines": {
+    "none":    { "spice": 0, "rules": ["no jokes", "no puns"] },
+    "light":   { "spice": 1, "rules": ["one friendly quip max", "no sarcasm"] },
+    "medium":  { "spice": 2, "rules": ["one playful analogy", "keep it warm"] },
+    "high":    { "spice": 3, "rules": ["two playful moments", "avoid niche references"] }
+  }
+}

--- a/bots/earthscope_post/symptom_guides.json
+++ b/bots/earthscope_post/symptom_guides.json
@@ -1,0 +1,29 @@
+{
+  "triggers": {
+    "kp_gte_5": {
+      "symptoms": ["restless sleep", "brain fog", "irritability"],
+      "tips": ["hydrate + electrolytes", "keep bedtime screen-free", "5-minute breath pacing"]
+    },
+    "bz_south": {
+      "symptoms": ["pressure headaches", "tingly/anxious edges", "sleep fragmentation"],
+      "tips": ["earthing/grounding walk", "neck/shoulder stretch", "magnesium-rich foods"]
+    },
+    "solar_radiation_s1plus": {
+      "symptoms": ["fatigue", "sensitive sinuses", "low mojo"],
+      "tips": ["focus short bursts of work", "take outdoor sunglasses", "gentle HRV-friendly movement"]
+    },
+    "drap_elevated": {
+      "symptoms": ["radio/static comms quirks", "low energy"],
+      "tips": ["skip long calls today", "message vs call", "short outdoor breaks"]
+    },
+    "cme_recent_earthward": {
+      "symptoms": ["sleep off-pattern", "odd vivid dreams"],
+      "tips": ["consistent lights-out", "cool the bedroom", "morning light exposure"]
+    }
+  },
+  "rotate_notes": [
+    "Rapid temperature swings or pressure drops can intensify symptoms for some people.",
+    "Local weather (humidity, pressure, lightning) can amplify how space weather feels.",
+    "Keep an eye on hydration when winds pick up — simple, but it helps a lot."
+  ]
+}

--- a/docs/NEW_AGENT_GUIDE.md
+++ b/docs/NEW_AGENT_GUIDE.md
@@ -11,6 +11,7 @@ Gaia Eyes combines a FastAPI backend, a Swift iOS app, and a WordPress front-end
 - **iOS app**: `/gaiaeyes-ios/ios`
 - **WordPress (site)**: `/wp-content`
 - **Docs**: `/docs` and root Markdown files
+- **Earthscope writer**: `/bots/earthscope_post` (daily_posts copy + card JSON)
 
 ## 3) Hard rules (do not violate)
 - Do **not** change naming conventions for tables, routes, env vars, or data keys.
@@ -27,6 +28,11 @@ Gaia Eyes combines a FastAPI backend, a Swift iOS app, and a WordPress front-end
 **Supabase access**
 - Backend writes directly to Supabase. Clients should prefer backend endpoints, not direct DB access.
 - Storage uploads use `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`.
+
+**Earthscope writer inputs**
+- Primary data source: `GAIA_BACKEND_BASE/v1/space/forecast/outlook` (fallbacks to marts + legacy JSON when missing).
+- Style/correlation guides live in `bots/earthscope_post/style_rules.json` and `bots/earthscope_post/symptom_guides.json`.
+- Key env toggles: `GAIA_BACKEND_BASE`, `STYLE_RULES_PATH`, `SYMPTOM_GUIDES_PATH`, `WRITER_LENS`, `WRITER_HUMOR`, `WRITER_TEMP`, `FORCE_PRESSURE_NOTE`, `OPENAI_WRITER_MODEL`.
 
 ## 5) API routing conventions (backend)
 Backend routes are grouped by domain under `app/routers/` and registered in `app/main.py`.


### PR DESCRIPTION
### Motivation
- Provide the writer a fuller consolidated space‑weather input (`/v1/space/forecast/outlook`) and safer, more varied copy generation while preserving back-compat for downstream renderers. 
- Introduce simple correlation guidance and rotating small notes so the daily post can suggest plausible "may‑feel" effects without making medical claims. 
- Enforce style constraints (banned terms, humor/tone controls) so prose is varied, safe, and never uses the forbidden word.

### Description
- Added writer style and guidance artifacts: `bots/earthscope_post/style_rules.json` (banned terms, softeners, humor guidelines) and `bots/earthscope_post/symptom_guides.json` (correlation triggers and rotating notes).  
- Added `bots/earthscope_post/prompt_templates.py` to centralize the LLM system/user messaging for the new JSON-schema writer flow.  
- Upgraded `bots/earthscope_post/earthscope_generate.py` to fetch the consolidated `outlook` endpoint (with `ensure_outlook_fallback`), pick 1–2 symptom/tip correlations, sanitize LLM prose against `banned_terms`, compose a richer `cards` payload (caption, stats, playbook, affects.note), and include `overview`, `lead`, and `cards` in the Supabase upsert while keeping backward compatibility for `body_markdown`/sections.  
- Documented new env toggles and writer inputs in `bots/earthscope_post/README.md` and `docs/NEW_AGENT_GUIDE.md`, and wired default env values into the daily GitHub Actions job (`.github/workflows/gaia_eyes_daily.yml`).  
- Verification step the reviewer can run locally: export `GAIA_BACKEND_BASE` and `OPENAI_API_KEY` then run `python bots/earthscope_post/earthscope_generate.py --dry-run` to inspect generated payload (the script uses the new outlook adapter and style/correlation files).

### Testing
- Ran Python compile check: `python -m py_compile bots/earthscope_post/earthscope_generate.py bots/earthscope_post/prompt_templates.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c12c8798c832a9005521f58a8a267)